### PR TITLE
Fix: Pass in `&` as part of the link sent with the token

### DIFF
--- a/apps/verify/behaviours/email-lookup-sender.js
+++ b/apps/verify/behaviours/email-lookup-sender.js
@@ -22,7 +22,9 @@ const checkDomain = (userEmailDomain) => {
 
 const getPersonalisation = (host, token) => {
   return {
-    'link': `http://${host + appPath + firstStep}?token=${token}`
+    // pass in `&` at the end in case there is another
+    // query e.g. ?hof-cookie-check
+    'link': `http://${host + appPath + firstStep}?token=${token}&`
   };
 };
 


### PR DESCRIPTION
Bug: sometimes hof adds `?hof-cookie` when you click on a link.  This means that this will be added to req.query.token.  Therefore, it won't find this in the redis db. Adding `&` will separate out this from the query string