### PR TITLE
MS-755 - Docker - wkhtmltopdf - install more dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/ukhomeofficedigital/nodejs-base:v8
 RUN yum clean all && yum update -y -q && yum clean all && yum -y upgrade
-RUN yum install -y wget fontconfig freetype libX11 libXext libXrender libjpeg libpng openssl xorg-x11-fonts-75dpi xorg-x11-fonts-Type1
+RUN yum install -y libX11 make gcc gcc-c++ krb5-devel git bzip2 ImageMagick fontconfig libXrender libXext xorg-x11-fonts-Type1 xorg-x11-fonts-75dpi freetype libpng zlib libjpeg-turbo wget openssl
 
 RUN wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox-0.12.5-1.centos7.x86_64.rpm && \
     rpm -Uvh wkhtmltox-0.12.5-1.centos7.x86_64.rpm


### PR DESCRIPTION
* On acp, the `wkhtmltopdf` failed for a weird reason.  `Error: QPainter::begin(): Returned false`.  It appears that it could be to do with the setup or not having all the required dependencies
* install the dependencies exactly how they are set up for EVW, another service on ACP using this package
* We `wkhtmltopdf` to convert our html to pdf