### PR TITLE
MS-755-PDF: Change public folder permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY package.json /app/package.json
 RUN npm --loglevel warn install --production  --no-optional
 COPY . /app
 RUN npm --loglevel warn run postinstall
-RUN chown -R nodejs:nodejs /public
+# Give nodejs user permissions to public folder. Nodejs user is set to 999 and the group 998
+RUN chown -R 999:998 /public && chown -R 999:998 public
 
 USER 999
 

--- a/config.js
+++ b/config.js
@@ -33,6 +33,6 @@ module.exports = {
   pdf: {
     template: './apps/pdf/views/pdf.html',
     // problems with creating temp folder so use images folder
-    tempLocation: './public/images'
+    tempLocation: 'public/images'
   }
 };


### PR DESCRIPTION
* PDF generation was not working because of permissions. When running on ACP, the user is nodejs not root.  Therefore, give access of the public folder to nodejs user which is set to 999 and the group 998
* Also set the temp location to the proper public area