### PR TITLE
Docker-compose: Run as nodejs user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "8081:8081"
     volumes:
       - "/app/public"
-    user: root
+    user: nodejs
     container_name: modern-slavery-app
 
   chrome-browser:


### PR DESCRIPTION
In ACP, the containers are run as nodejs user NOT as root.  Therefore, run it locally how it will run on ACP