### PR TITLE
MS-756 - PDF generator - Fix unit tests

### DIFF
--- a/apps/pdf/util/pdf-generator.js
+++ b/apps/pdf/util/pdf-generator.js
@@ -9,7 +9,8 @@ module.exports = {
     return new Promise((resolve, reject) => {
       const file = `${destination}/${tempName}`;
       // first read the template
-      wkhtmltopdf(fs.createReadStream(html), (err, stream) => {
+      const readStream = fs.createReadStream(html);
+      wkhtmltopdf(readStream, (err, stream) => {
         if (err) {
           console.log(`Pdf generation: Failed, something went wrong
             reading the template ${html}, further details here -> ${err}`);

--- a/test/unit/pdf/behaviours/generate-send-pdf.test.js
+++ b/test/unit/pdf/behaviours/generate-send-pdf.test.js
@@ -50,34 +50,32 @@ describe('/apps/pdf/behaviours/generate-send-pdf', () => {
     });
 
     // test not running properly
-    xit('sends an email', (done) => {
+    xit('sends an email', () => {
       req.form = {
         values: {
           email: 's@mail.com'
         }
       };
-      pdfGeneratorStub.generate.resolves('a');
-      fsStub.readFile.resolves('b');
-      fsStub.unlink.resolves('file');
+      pdfGeneratorStub.generate.resolves('file');
+      fsStub.readFile.yields(null, 'file');
+      fsStub.unlink.yields(null);
       instance.saveValues(req, res, () => {
-        NotifyClient.prototype.sendEmail.should.have.been.called;
-        done();
+        return expect(NotifyClient.prototype.sendEmail).to.have.been.called;
       });
     });
 
     // test not running properly
-    xit('calls pdf generator', (done) => {
+    xit('calls pdf generator', () => {
       req.form = {
         values: {
           email: 's@mail.com'
         }
       };
-      pdfGeneratorStub.generate.yieldAsync('a');
-      fsStub.readFile.yieldAsync('b');
-      fsStub.unlink.yieldAsync('file');
+            pdfGeneratorStub.generate.resolves('file');
+      fsStub.readFile.yields(null, 'file');
+      fsStub.unlink.yields(null);
       instance.saveValues(req, res, () => {
-        pdfGeneratorStub.generate.should.eventually.be.called;
-        done();
+        return expect(pdfGeneratorStub.generate).to.be.called;
       });
     });
   });

--- a/test/unit/pdf/util/pdf-generator.test.js
+++ b/test/unit/pdf/util/pdf-generator.test.js
@@ -1,42 +1,50 @@
 'use strict';
 
 const proxyquire = require('proxyquire').noCallThru();
-
-const html2pdfStub = sinon.stub();
+const stream = require('stream');
+const Readable = stream.Readable;
+const Writable = stream.Writable;
+let html2pdfStub = sinon.stub();
 const fsStub = {
   createReadStream: sinon.stub(),
   createWriteStream: sinon.stub()
 };
-
 const pdfGenerator = proxyquire('../../../../apps/pdf/util/pdf-generator',
-  {
-    'wkhtmltopdf': html2pdfStub,
-    'fs': fsStub
-  });
+    {
+      'fs': fsStub,
+      'wkhtmltopdf': html2pdfStub
+    });
 
 describe('/apps/pdf/util/pdf-generator', () => {
-  it('calls wkhtmltopdf', () => {
-    fsStub.createReadStream.returns('test');
-    pdfGenerator.generate('<html></html>', 'path', 'myfile.pdf');
-    html2pdfStub.should.have.been.calledWith('test');
+  it('promise should be rejected', () => {
+    html2pdfStub
+    // yields calls the first callback with the arguments in the parenthesis
+      .yields('err', null);
+    const result = pdfGenerator.generate('nohtml', './path/', 'myfile.pdf');
+    // always return with chai-as-promised for assertion
+    // https://github.com/domenic/chai-as-promised/issues/238
+    expect(result).to.be.a('Promise');
+    return expect(result).to.be.rejected;
   });
 
-  it('is a promise', () => {
-    pdfGenerator.generate('<html></html>', 'path', 'myfile.pdf').should.be.a('Promise');
-  });
-
-  describe('Promise', () => {
-    it('rejects an error', () => {
-      fsStub.createReadStream.yields('err', null);
-      const result = pdfGenerator.generate('nohtml', 'path', 'myfile.pdf');
-        result.should.eventually.be.rejected;
-    });
-
-    // test not running properly
-    xit('fulfills a valid file', () => {
-      fsStub.createReadStream.yields(null, 'test');
-      const result = pdfGenerator.generate('<html></html>', 'path', 'myfile.pdf');
-        result.should.eventually.be.rejected;
-    });
+  // need to create read and write streams for this test
+  // so we can get the right response for the subsequent functions to work
+  it('promise should be fulfilled', () => {
+    const readStream = new Readable();
+    readStream.push('your text here');
+    readStream.push(null);
+    const writeStream = new Writable();
+    // https://stackoverflow.com/questions/21491567/how-to-implement-a-writable-stream
+    // eslint-disable-next-line no-underscore-dangle
+    writeStream._write = (chunk, encoding, done) => done();
+    fsStub.createReadStream.returns(readStream);
+    fsStub.createWriteStream.returns(writeStream);
+    html2pdfStub.
+      yields(null, readStream);
+    // chai-promise requires a `return` in assertions for mocha to pick them up
+    // https://github.com/domenic/chai-as-promised/issues/238
+    const result = pdfGenerator.generate('<html></html>', 'path', 'myfile.pdf');
+    expect(result).to.be.a('Promise');
+    return expect(result).to.be.fulfilled;
   });
 });


### PR DESCRIPTION
* chai-as-promise always requires `return expect`
* yields: calls the callback with arguments provided, if no args just call the callback