### PR TITLE
Drone - remove PR build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,13 +19,6 @@ pipeline:
     when:
       event: [push, pull_request]
 
-  build_app_pr:
-    image: quay.io/ukhomeofficedigital/drone-docker
-    commands:
-      - docker build -t app-$${DRONE_COMMIT_SHA} .
-    when:
-      event: pull_request
-
   build_app:
     image: quay.io/ukhomeofficedigital/drone-docker
     commands:


### PR DESCRIPTION
Seems unnecessary as we already have something else that gets built for PR, build_app