### PR TITLE
Drone: Don't run acceptance test on branch unless PR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,7 @@ pipeline:
         - pull_request
 
   # Run acceptance tests using docker-compose only
+  # Run this on pull_requests
   acceptance_test:
     image: docker/compose:1.23.2
     environment:
@@ -20,8 +21,20 @@ pipeline:
       - docker-compose exec -T app sh -c 'npm run test:docker-acceptance'
     when:
       event:
-        - push
         - pull_request
+
+  # Run acceptance tests using docker-compose only
+  # Run it on master branch as well
+  acceptance_test:
+    image: docker/compose:1.23.2
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker-compose --verbose up -d --build chrome-browser app redis
+      - docker-compose exec -T app sh -c 'npm run test:docker-acceptance'
+    when:
+      branch: master
+      event: push
 
   build_app:
     image: quay.io/ukhomeofficedigital/drone-docker

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The location of the user pathway tests are in the directory: `/modern-slavery/ac
 
 The test scripts utilise the environment variables `BROWSER_TYPE` & `BROWSER_DEMO` to determine what the test files within the directory `/modern-slavery/acceptance-test/user-pathways/` uses as its browser and whether the browser runs slower for demonstration purposes.
 
-`BROWSER_TYPE` can be left blank or set to `local` for local machine browser testing. This variable can be set to `remote` for remote browser testing
+`BROWSER_TYPE` can be left blank or set to `local` for local machine browser testing. This variable can be set to `remote` for remote browser testing.
 
 `BROWSER_DEMO`can be left blank so the tests run at normal speed or can be set so the test runs at a slower speed.
 


### PR DESCRIPTION
- Aim is to save time
- Every PR has two builds, once when you push and another time when you create a PR
- Only run the unit tests for the push to a branch
- Only run acceptance tests for pushes into a PR

Note: this might not work so I'll have to test it