### PR TITLE
MS-942: fix: update summary-table-potential-victim.html

### DIFF
--- a/apps/nrm/views/partials/summary-table-potential-victim.html
+++ b/apps/nrm/views/partials/summary-table-potential-victim.html
@@ -211,6 +211,7 @@
         </tr>
       {{/values.pv-phone-number-yes}}
 
+      {{#values.does-pv-have-children}}
       <tr>
         <td>{{#t}}pages.confirm.fields.pv-ho-reference.label{{/t}}</td>
         <td class="no-white-space">
@@ -227,5 +228,6 @@
           <a href="/nrm/pv-ho-reference/edit#pv-ho-reference" class="button">Change</a>
         </td>
       </tr>
+      {{/values.does-pv-have-children}}
   </tbody>
 </table>


### PR DESCRIPTION
Fixed check your answer - Home Office Reference displays no information

If the user has not entered does-pv-have-children question then they will not need to see this answer.
another way of saying they have not gone down the duty to notify user journey.