### PR TITLE
Fix: allow chrome browser to be installed

### DIFF
--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get update && \
   apt-get install -yq curl libgconf-2-4
 
 # Install Google Chrome
-# the --allow-unauthenticated command is a temporary solution in order to
-# allow google chrome to be installed when runnning docker acceptance tests
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get update --allow-unauthenticated && \

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get update && \
-  apt-get install -y google-chrome-unstable --no-install-recommends && \
+  apt-get install -y --allow-unauthenticated google-chrome-unstable --no-install-recommends && \
   rm -fr /var/lib/apt/lists/* && \
   # Uninstall Curl, it's configuration files and the installation file from Ubuntu
   apt-get purge --auto-remove -y curl && \

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && \
   apt-get install -yq curl libgconf-2-4
 
 # Install Google Chrome
+# the --allow-unauthenticated command is a temporary solution in order to
+# allow chrome to be installed when runnning docker acceptance tests
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
-  # the --allow-unauthenticated command is a temporary solution in order to
-  # allow chrome to be installed when runnning docker acceptance tests
   apt-get update --allow-unauthenticated && \
   apt-get install -y google-chrome-unstable --no-install-recommends && \
   rm -fr /var/lib/apt/lists/* && \

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 
 # Install Google Chrome
 # the --allow-unauthenticated command is a temporary solution in order to
-# allow chrome to be installed when runnning docker acceptance tests
+# allow google chrome to be installed when runnning docker acceptance tests
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get update --allow-unauthenticated && \

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -8,10 +8,12 @@ RUN apt-get update && \
   apt-get install -yq curl libgconf-2-4
 
 # Install Google Chrome
+# the --allow-unauthenticated command is a temporary solution in order to
+# allow google chrome to be installed when runnning docker acceptance tests
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get update --allow-unauthenticated && \
-  apt-get install -y google-chrome-unstable --no-install-recommends && \
+  apt-get install -y google-chrome-unstable --no-install-recommends --allow-unauthenticated && \
   rm -fr /var/lib/apt/lists/* && \
   # Uninstall Curl, it's configuration files and the installation file from Ubuntu
   apt-get purge --auto-remove -y curl && \

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
 # Install Google Chrome
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
+  # the --allow-unauthenticated command is a temporary solution in order to
+  # allow chrome to be installed when runnning docker acceptance tests
   apt-get update --allow-unauthenticated && \
   apt-get install -y google-chrome-unstable --no-install-recommends && \
   rm -fr /var/lib/apt/lists/* && \

--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && \
 # Install Google Chrome
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
-  apt-get update && \
-  apt-get install -y --allow-unauthenticated google-chrome-unstable --no-install-recommends && \
+  apt-get update --allow-unauthenticated && \
+  apt-get install -y google-chrome-unstable --no-install-recommends && \
   rm -fr /var/lib/apt/lists/* && \
   # Uninstall Curl, it's configuration files and the installation file from Ubuntu
   apt-get purge --auto-remove -y curl && \


### PR DESCRIPTION
When running acceptance tests we want to allow the installation of google chrome

Chrome version is unstable currently and we will need to seek future alternative.

The version of chrome we use to run puppeteer acceptance tests now flags up a warning when we try to install chrome on docker.

Since this version of chrome is unstable the new rules ( I think, since the tests have been running fine up until today) forces us to either change the chrome browser version we are using or add a ‘--allow-unauthenticated’  command when installing the package.