### PR TITLE
MS-1214 task: remove FRs from PDF email sent by Notify

### DIFF
--- a/apps/nrm/behaviours/generate-send-pdf.js
+++ b/apps/nrm/behaviours/generate-send-pdf.js
@@ -46,13 +46,8 @@ module.exports = superclass => class extends superclass {
     const session = req.sessionModel.attributes;
     const data = await util.transformData(session);
     const file = await pdfPuppeteer.generate(templateFile, tempLocation, tempName, data);
-    const firstResponderEmail = req.sessionModel.get('user-email');
 
     await sendEmailWithFile(file, caseworkerEmail);
-
-    if (firstResponderEmail) {
-      await sendEmailWithFile(file, firstResponderEmail);
-    }
 
     await deleteFile(file);
 

--- a/test/unit/nrm/behaviours/generate-send-pdf.test.js
+++ b/test/unit/nrm/behaviours/generate-send-pdf.test.js
@@ -58,7 +58,6 @@ describe('/apps/pdf/behaviours/generate-send-pdf', () => {
       fsStub.unlink.yields(null);
       sinon.stub(Base.prototype, 'saveValues');
       sinon.stub(NotifyClient.prototype, 'sendEmail').resolves('email sent');
-      req.sessionModel.get = sinon.stub();
     });
     afterEach(() => {
       Base.prototype.saveValues.restore();


### PR DESCRIPTION
- Remove the functionality added under MS-1099 in the interim release that copies the PDF to the FR.

- Part of - Retain PDF File for go-live implementation