### PR TITLE
Disable sending to casework backend by default

### DIFF
--- a/apps/nrm/behaviours/casework-submission.js
+++ b/apps/nrm/behaviours/casework-submission.js
@@ -3,6 +3,7 @@
 const CaseworkModel = require('../models/i-casework');
 const StatsD = require('hot-shots');
 const client = new StatsD();
+const appConfig = require('../../../config');
 
 const Compose = func => superclass => class extends superclass {
 
@@ -34,7 +35,11 @@ module.exports = config => {
           return next(err);
         }
         const model = new Model(req.sessionModel.toJSON());
-        req.sessionModel.set('jsonPayload', config.prepare(req.sessionModel.toJSON()));
+
+        let caseWorkPayload = appConfig.writeToCasework ? config.prepare(req.sessionModel.toJSON()) :
+          { info: 'No submission was made to icasework' };
+
+        req.sessionModel.set('jsonPayload', caseWorkPayload);
         req.log('debug', `Sending icasework submission to ${model.url()}`);
         model.save()
           .then(data => {

--- a/apps/nrm/behaviours/generate-send-pdf.js
+++ b/apps/nrm/behaviours/generate-send-pdf.js
@@ -55,7 +55,7 @@ module.exports = superclass => class extends superclass {
     await sendEmailWithFile(file, caseworkerEmail, req);
 
     if (firstResponderEmail) {
-      await sendEmailWithFile(file, firstResponderEmail);
+      await sendEmailWithFile(file, firstResponderEmail, req);
     }
 
     await deleteFile(file, req);

--- a/apps/nrm/models/i-casework.js
+++ b/apps/nrm/models/i-casework.js
@@ -38,7 +38,7 @@ module.exports = class CaseworkModel extends Model {
     const options = this.requestConfig({});
     options.form = this.prepare();
     options.method = 'POST';
-    if (!config.icasework.secret || !config.icasework.key && config.env !== 'production') {
+    if (!config.writeToCasework || !config.icasework.secret || !config.icasework.key && config.env !== 'production') {
       return Promise.resolve({
         createcaseresponse: {
           caseid: 'mock caseid'

--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -17,7 +17,9 @@ module.exports = data => {
   response['Customer.ContactMethod'] = _.isArray(data['pv-contact-details']) ?
     'Email, Post' : _.upperFirst(data['pv-contact-details']);
   response['Customer.Alias'] = data['pv-name-nickname'];
-  response['Case.Jurisdiction'] = data['fr-location'].toUpperCase().replace(' ', '');
+  if (data['fr-location']) {
+    response['Case.Jurisdiction'] = data['fr-location'].toUpperCase().replace(' ', '');
+  }
   if (data['pv-dob']) {
     response['Customer.Custom7'] = 'Yes';
     response['Customer.DOB'] = data['pv-dob'];

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ const localhost = () => `${process.env.LISTEN_HOST || '0.0.0.0'}:${process.env.P
 module.exports = {
   env: env,
   useMocks: useMocks,
+  writeToCasework: (process.env.WRITE_TO_CASEWORK === 'true') ? true : false,
   hostUrl: process.env.HOST_URL || 'http://localhost:8081',
   redis: {
     port: process.env.REDIS_PORT || '6379',


### PR DESCRIPTION
You now need to set an env var of `WRITE_TO_CASEWORK=true` else it will use the default mock backend for casework

I also spotted a few bugs in the code while I was working on this so there are a few fixes in there also