### PR TITLE
MS-1369 Point emails to gov notify Modern slavery test

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,18 @@ $ docker-compose up -d --build chrome-browser app redis
 
 ## Email functionality  <a name="email-functionality"></a>
 
-You'll need the test Gov Notify Key called, `NOTIFY_KEY`, to run the email functionality properly. Do NOT use the Production key.
+We use [Gov Notify](https://notifications.service.gov.uk/sign-in) to send emails. We have two accounts:
+
+1. Modern slavery for our Live service. This is on our production environment
+2. Modern slavery test for testing. This is on our dev, uat and preprod environments
+
+In order to run the email functionality, you'll need the API Gov Notify Key called, `NOTIFY_KEY` for the Modern slavery test service. Do NOT use the Production key.
 
 This can be obtained from a developer in the team.  It is recommended to have a `.env` file with the environment variable and then run the app like so:
 
 ```bash
 $ npm run dev -- --env
 ```
-
-To get an email from gov notify, you'll need to be added to the email list for testing on [gov notify](https://www.notifications.service.gov.uk/sign-in)
 
 ## Skip email verify step  <a name="skip-email-verify-step"></a>
 

--- a/config.js
+++ b/config.js
@@ -31,11 +31,11 @@ module.exports = {
   tokenExpiry: 86400,
   govukNotify: {
     notifyApiKey: process.env.NOTIFY_KEY || '',
-    templateUserAuthId: '56b5a84f-7024-41d3-bd08-26521435be16',
-    templatePDF: '90fa07d2-50ab-468f-bc14-4bcaf7f7b34d',
-    templateFeedback: '5bf7a9df-eec6-4e38-95d5-5107ab41d87f',
-    caseworkerEmail: process.env.CASEWORKER_EMAIL || 'ms-test@homeoffice.gov.uk',
-    feedbackEmail: process.env.FEEDBACK_EMAIL || 'ms-test@homeoffice.gov.uk'
+    templateUserAuthId: process.env.TEMPLATE_USER_AUTHORISATION_ID || 'fe0408cb-24f0-4b5f-9bdb-6569834039fb',
+    templatePDF: process.env.TEMPLATE_PDF || 'd48b84c8-9350-4cf8-b31c-8cc4ef8237f1',
+    templateFeedback: process.env.TEMPLATE_FEEDBACK || '92b314e9-8ed5-4762-a8e2-7f208cdf3836',
+    caseworkerEmail: process.env.CASEWORKER_EMAIL || 'serviceopstesting@digital.homeoffice.gov.uk',
+    feedbackEmail: process.env.FEEDBACK_EMAIL || 'serviceopstesting@digital.homeoffice.gov.uk'
   },
   icasework: {
     url: process.env.ICASEWORK_URL || 'https://uat.icasework.com',


### PR DESCRIPTION
Previously, emails were pointing to the production Modern slavery account.  This meant the following:
* Unnecessary users having access to prod emails
* Analytics not being accurate because of test and also live emails being sent out together