### PR TITLE
MS-1457 Bump hof version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-slavery",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4862,9 +4862,9 @@
       }
     },
     "hof": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/hof/-/hof-13.3.0.tgz",
-      "integrity": "sha512-KqHAWUapzmuv9Ux8IXTPjKo3BCHFeO+0tgJ24sY4iCqciir2qn6WkqcGSsI0PQzTBGuCzLmWpRu8Wu0jx7u8uA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/hof/-/hof-13.4.0.tgz",
+      "integrity": "sha512-qw5HgeMJdpf236KrAjWmKJ5bdm1dbzCifZSD6hYB4gzN4TBvZZ8w1AdSlG8v1aWJQlSWOlyyqW3+30As63cn5w==",
       "requires": {
         "body-parser": "^1.15.1",
         "churchill": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chai-shallow-deep-equal": "^1.4.6",
     "express": "^4.16.4",
     "govuk-frontend": "^2.7.0",
-    "hof": "^13.3.0",
+    "hof": "^13.4.0",
     "hof-behaviour-summary-page": "^2.0.0",
     "hof-build": "^1.6.0",
     "hof-component-date": "^1.4.0",


### PR DESCRIPTION
A newer version of hof adds a readiness check endpoint.
As the readiness check is now required to run in Kubernetes using our
current config, this commit explicitly bumps the version to ensure
compatibility.