### PR TITLE
MS-1507 Liberalise email validation

### DIFF
--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -1,0 +1,3 @@
+{
+  "isValidEmail":  "Enter a valid email address"
+}

--- a/apps/common/validators.js
+++ b/apps/common/validators.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/*
+ * Validator methods should return false (or falsy value) for *invalid* input,
+ * and should return true (or truthy value) for valid input.
+ *
+ * For more information, see https://github.com/UKHomeOfficeForms/hof-form-controller
+ */
+
+module.exports = {
+  isValidEmail: (email) => [
+    typeof email === 'string',
+    email.split('@').length === 2,
+    /^[^\s@]+@[^\.\s]+\.[^\s]+$/i.test(email),
+  ].every((x) => x),
+};

--- a/apps/verify/fields/index.js
+++ b/apps/verify/fields/index.js
@@ -2,6 +2,8 @@
 
 const organisations = require('ms-organisations');
 
+const { isValidEmail } = require('../../common/validators.js');
+
 module.exports = {
   'user-organisation': {
     mixin: 'select',
@@ -14,10 +16,10 @@ module.exports = {
   },
   'user-email': {
     mixin: 'input-text',
-    validate: ['required', 'email', {'type': 'maxlength', 'arguments': [15000]}],
+    validate: ['required', isValidEmail, {'type': 'maxlength', 'arguments': [15000]}],
   },
   'confirm-email': {
     mixin: 'input-text',
-    validate: ['required', 'email', {'type': 'maxlength', 'arguments': [15000]}]
+    validate: ['required', isValidEmail, {'type': 'maxlength', 'arguments': [15000]}]
   },
 };

--- a/test/unit/common/validators.test.js
+++ b/test/unit/common/validators.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const validators = require('../../../apps/common/validators');
+
+describe('apps/common/validators', () => {
+
+  it('should reject emails with spaces', () => {
+   const result = [
+    ' test@example.com',
+    'test@example.com ',
+    'test @ example.com',
+    ' test@example.com ',
+    't est @ example.com',
+    'test\t@example.com'
+   ].map(validators.isValidEmail);
+    result.should.not.contain(true);
+  });
+
+  it('should accept emails with strange domain portions', () => {
+    const result = [
+      'test@example.com',
+      'test@example.gov.uk',
+      'test@subdomain.example.com',
+      'test@example.international',
+      'test@example.xn--kgbechtv',
+      'test@example.测试',
+    ].map(validators.isValidEmail);
+    result.should.not.contain(false);
+  });
+
+  it('should accept emails with strange username portions', () => {
+    const result = [
+      'firstname.lastname@example.com',
+      'FirstName.LastName@example.com',
+      'firstname.o\'lastname@example.com',
+      '"name"@example.com'
+    ].map(validators.isValidEmail);
+    result.should.not.contain(false);
+  });
+
+});


### PR DESCRIPTION
The email validation bundled with hof is overly restrictive.
This commit liberalises the validation to essentially accept anything
that has one @ sign and at least one dot in the domain portion of the
address.

A particular problem with the old code is that it wouldn't accept
apostrophes in the username portion; this commit fixes that.