### PR TITLE
MS-1554 Remove extraneous space from link text

### DIFF
--- a/apps/verify/views/start.html
+++ b/apps/verify/views/start.html
@@ -25,9 +25,8 @@
     <p lass="govuk-body">{{#t}}pages.start.paragraph-4{{/t}}</p>
 
     <div class="govuk-inset-text">
-      {{#t}}pages.start.div-1{{/t}} <a href="https://www.modernslaveryhelpline.org/report">
-        {{#t}}pages.start.div-1-link-text-1{{/t}}
-      </a>.
+      {{#t}}pages.start.div-1{{/t}}
+      <a href="https://www.modernslaveryhelpline.org/report">{{#t}}pages.start.div-1-link-text-1{{/t}}</a>.
     </div>
   </div>
 


### PR DESCRIPTION
Before:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/817054/71897769-6da61600-314f-11ea-9548-44bda3d7fa9c.png">

After:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/817054/71897801-80204f80-314f-11ea-94f0-cda28e181e6f.png">
