### PR TITLE
MS-929 Add full-width behaviour

### DIFF
--- a/apps/nrm/behaviours/full-width.js
+++ b/apps/nrm/behaviours/full-width.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const superLocals = super.locals(req, res);
+    superLocals.columnWidth = 'full-width';
+    return superLocals;
+  }
+};

--- a/apps/nrm/index.js
+++ b/apps/nrm/index.js
@@ -15,6 +15,7 @@ const ResetOnChange = require('./behaviours/reset-on-change');
 const formatAnswers = require('./behaviours/format-answers');
 const confirmation = require('./behaviours/confirmation');
 const deleteOnChange = require('./behaviours/delete-on-change');
+const fullWidth = require('./behaviours/full-width');
 const whereExploitationHappenedUk = require('./behaviours/where-exploitation-happened-uk');
 const Submission = require('./behaviours/casework-submission');
 const submission = Submission({
@@ -618,6 +619,7 @@ module.exports = {
         hideAndShowSummaryFields,
         getPageCustomBackLink('confirm'),
         generateSendPdf,
+        fullWidth,
         submission,
         'complete'
       ],

--- a/apps/nrm/views/partials/maincontent-left.html
+++ b/apps/nrm/views/partials/maincontent-left.html
@@ -1,0 +1,11 @@
+{{$content-outer}}
+{{$preloader}}{{/preloader}}
+  <div class="column-{{columnWidth}}{{^columnWidth}}two-thirds{{/columnWidth}}">
+    <q>column-{{columnWidth}}{{^columnWidth}}two-thirds{{/columnWidth}}</q>
+    {{$validationSummary}}{{/validationSummary}}
+    <header>
+      <h1>{{$header}}{{/header}}</h1>
+    </header>
+    {{$content}}{{/content}}
+  </div>
+{{/content-outer}}


### PR DESCRIPTION
This commit lets you customise the width of the content container on a
per step basis. Previously, they were all hardcoded to two thirds of
page width, which is great most of the time but not helpful for the
final "check your answers" page.

This commit overrides the template partial defined in
hof-template-partials to allow a res.local.columnWidth to amend the
class of the content container. It also defines a new "full width"
behaviour in order to set that new local.

We also add this behaviour to the "check your answers" page of the nrm
app. The other apps don't seem to have a corresponding CYA page.