### PR TITLE
MS-1100 email missing from referral confirmation

### DIFF
--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -310,7 +310,7 @@
     "heading-2-paragraph-1": "Support can take up to 5 days to start. If they need help immediately, you’ll need to contact the relevant provider or local authority for more information.",
     "heading-2-link-1": "Contact a support provider",
     "heading-3": "Contact us",
-    "heading-3-paragraph-1": "nationalreferralmechanism@homeoffice.gov.uk",
+    "heading-3-paragraph-1": "Email: nationalreferralmechanism@homeoffice.gov.uk",
     "heading-3-paragraph-2": "Telephone: 0207 035 5689",
     "heading-3-paragraph-3": "Back to the",
     "heading-3-paragraph-3-link-1": "first responder guidance",


### PR DESCRIPTION
Added Email: before nationalreferralmechanism@homeoffice.gov.uk for readability