### PR TITLE
MS-1239 Fix capitalisation in "Not Sure"for under 18 question

### DIFF
--- a/apps/nrm/translations/src/en/fields.json
+++ b/apps/nrm/translations/src/en/fields.json
@@ -66,7 +66,7 @@
         "label": "No"
       },
       "not-sure": {
-        "label": "Not Sure"
+        "label": "Not sure"
       }
     }
   },


### PR DESCRIPTION
Replacement pull request with correct username and email for me.

Corrected 'Not Sure' to 'Not sure' 