### PR TITLE
MS-1174 under 18 step: move hidden content to main body

### DIFF
--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -28,17 +28,11 @@ module.exports = {
     legend: {
       className: 'visuallyhidden'
     },
-    options: [{
-      value: 'yes',
-      toggle: 'yes-toggle-content',
-      child: 'partials/pv-under-age-panel-yes'
-    }, {
-      value: 'no',
-    }, {
-      value: 'not-sure',
-      toggle: 'not-sure-toggle-content',
-      child: 'partials/pv-under-age-panel-not-sure'
-    }]
+    options: [
+      'yes',
+      'no',
+      'not-sure'
+    ]
   },
   'local-authority-contacted-about-child-local-authority-name': {
     mixin: 'select',

--- a/apps/nrm/views/content/pv-under-age.md
+++ b/apps/nrm/views/content/pv-under-age.md
@@ -1,0 +1,3 @@
+If you’re not sure of the potential victim’s age, you’ll need to refer them to the relevant local authority for an age assessment. They will continue to be treated as a child until a decision on their age is made.
+
+If they’re under 18 or you’re not sure, you must explain to them how organisations such as the Home Office will use their information.

--- a/apps/nrm/views/partials/pv-under-age-panel-not-sure.html
+++ b/apps/nrm/views/partials/pv-under-age-panel-not-sure.html
@@ -1,4 +1,0 @@
-<div id="not-sure-toggle-content" class="panel-indent">
-    <p>{{#t}}fields.pv-under-age.options.not-sure.toggle-content{{/t}}</p>
-    <p>{{#t}}fields.pv-under-age.options.not-sure.toggle-content-2{{/t}}</p>
-</div>

--- a/apps/nrm/views/partials/pv-under-age-panel-yes.html
+++ b/apps/nrm/views/partials/pv-under-age-panel-yes.html
@@ -1,3 +1,0 @@
-<div id="yes-toggle-content" class="panel-indent">
-    <p>{{#t}}fields.pv-under-age.options.yes.toggle-content{{/t}}</p>
-</div>

--- a/apps/nrm/views/pv-under-age.html
+++ b/apps/nrm/views/pv-under-age.html
@@ -1,0 +1,9 @@
+{{<partials-page}}
+{{$page-content}}
+  {{#markdown}}pv-under-age{{/markdown}}
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+  {{#input-submit}}continue{{/input-submit}}
+{{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
Previously, if you clicked on radio buttons, some content would appear. This failed an accessibility audit as a High issue.  This means we have to resolve it quickly.