### PR TITLE
Add secondary button

### DIFF
--- a/apps/nrm/views/pv-under-age.html
+++ b/apps/nrm/views/pv-under-age.html
@@ -1,7 +1,7 @@
 {{<partials-page}}
   {{$page-content}}
     {{#renderField}}pv-under-age{{/renderField}}
-    <a href="/nrm/save-report" class="button">Save and exit</a>
     {{#input-submit}}continue{{/input-submit}}
+    <a href="/nrm/save-report" class="button-secondary">Save and exit</a>
   {{/page-content}}
 {{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -144,3 +144,7 @@ textarea {
   margin-top: -30px;
   margin-bottom: 30px;
 }
+
+.button-secondary {
+  @include button($grey-3);
+}


### PR DESCRIPTION
It's currently unclear which button to click to proceed to the next
page. This commit moves the "save and exit" button to be after the
"continue" button, and colours it grey instead of green.

For more information on secondary buttons, see the GOV.UK Design System:
https://design-system.service.gov.uk/components/button/#secondary-buttons

The concept of secondary buttons did not exist in GOV.UK Elements, which
hof continues to use. Therefore, this commit also adds some SCSS to
add a .button-secondary class.