### PR TITLE
SD-94: updated ms-uk-local-authorities to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6592,9 +6592,9 @@
       "integrity": "sha512-kkdaCxhWZ/ltv5EybZpAxO05c2aWGELCj/zjqTaOzMDlZo3f7/sBx4p/utL4M42IjYhBl/L28qjfGgM80qD02w=="
     },
     "ms-uk-local-authorities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms-uk-local-authorities/-/ms-uk-local-authorities-2.1.1.tgz",
-      "integrity": "sha512-nqSgg/D6yxuom/2ninRULSDxF23rd/kDiwbGo/Ds/aexOyiCEpSAifyNAq5wOECfpePNvYlkClFwVRRDmZCusA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ms-uk-local-authorities/-/ms-uk-local-authorities-2.2.1.tgz",
+      "integrity": "sha512-43tqOKfR9Sq2Y0iVIifIeuYbUxsfwRCIE4NPvPrmU7v6EZqT19cl3rmVK6GRFcu7/y81rMYV5gDoEOijRc6Bhw=="
     },
     "ms-uk-police-forces": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ms-nationalities": "^1.0.1",
     "ms-organisations": "^1.5.0",
     "ms-uk-cities-and-towns": "^2.0.2",
-    "ms-uk-local-authorities": "^2.1.1",
+    "ms-uk-local-authorities": "^2.2.1",
     "ms-uk-police-forces": "^2.0.0",
     "ms-uk-regions": "^2.1.1",
     "notifications-node-client": "^4.5.1",


### PR DESCRIPTION
Jira Ticket: https://collaboration.homeoffice.gov.uk/jira/browse/SD-94

Linked PR: https://github.com/UKHomeOffice/ms-uk-local-authorities/pull/7

Changes: 

1. ms-uk-local-authorities version update to 2.2.1. 