### PR TITLE
SD-96 bump ms-email-domain npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6572,9 +6572,9 @@
       "integrity": "sha512-t+wlqwKFJl0yUNtwLbUWBd0irrsBBrTbHAK22dDN9Ut9H0zOf6iVKNz0DAINDtE2rgf+8hmzGt7SSmXAN7Im/A=="
     },
     "ms-email-domains": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.0.tgz",
-      "integrity": "sha512-3YUpltSRHI9XQ1i/dGFzaGHuZU5Hk+YUz6pJavgTCMvP9YUZdHA1hAPjasgvM/TtkEuSLRPqFDjsclZkQj7huA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.1.tgz",
+      "integrity": "sha512-Kl9eQRTcKPG38Q7/XNFWixvEUA6mVVzTFN54XNk2y40EVMBFJ2gK8tMWGh0TzzKWSRUG0xEX7B7TP0gNyyxWXA=="
     },
     "ms-nationalities": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "^7.0.1",
     "moment": "^2.27.0",
     "ms-countries": "^1.0.0",
-    "ms-email-domains": "^2.2.0",
+    "ms-email-domains": "^2.2.1",
     "ms-nationalities": "^1.0.1",
     "ms-organisations": "^1.5.0",
     "ms-uk-cities-and-towns": "^2.0.2",


### PR DESCRIPTION
## What

bump ms-email-domain npm package

## Why

This has nccgroup in the list. They've been added to do ITHC