### PR TITLE
SD-96 Update ms-email-domains add more ncc email domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6572,9 +6572,9 @@
       "integrity": "sha512-t+wlqwKFJl0yUNtwLbUWBd0irrsBBrTbHAK22dDN9Ut9H0zOf6iVKNz0DAINDtE2rgf+8hmzGt7SSmXAN7Im/A=="
     },
     "ms-email-domains": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.1.tgz",
-      "integrity": "sha512-Kl9eQRTcKPG38Q7/XNFWixvEUA6mVVzTFN54XNk2y40EVMBFJ2gK8tMWGh0TzzKWSRUG0xEX7B7TP0gNyyxWXA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.2.tgz",
+      "integrity": "sha512-PtG7bdddPLkarkyYIYbJSdOTvas3WD2qzeyjNSZl1G7GiqJYqo+GchEUHDd9g9XMgafH+iCp8UextaWoXERL1Q=="
     },
     "ms-nationalities": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "^7.0.1",
     "moment": "^2.27.0",
     "ms-countries": "^1.0.0",
-    "ms-email-domains": "^2.2.1",
+    "ms-email-domains": "^2.2.2",
     "ms-nationalities": "^1.0.1",
     "ms-organisations": "^1.5.0",
     "ms-uk-cities-and-towns": "^2.0.2",


### PR DESCRIPTION
## What

Use newer ms-email-domains npm version

## Why

This is for ITHC and include more ncc email domains