### PR TITLE
update ms-email-domains-to-version-2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6572,9 +6572,9 @@
       "integrity": "sha512-t+wlqwKFJl0yUNtwLbUWBd0irrsBBrTbHAK22dDN9Ut9H0zOf6iVKNz0DAINDtE2rgf+8hmzGt7SSmXAN7Im/A=="
     },
     "ms-email-domains": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.2.tgz",
-      "integrity": "sha512-PtG7bdddPLkarkyYIYbJSdOTvas3WD2qzeyjNSZl1G7GiqJYqo+GchEUHDd9g9XMgafH+iCp8UextaWoXERL1Q=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.3.tgz",
+      "integrity": "sha512-wGZr9l3H1Bl0iAaBjZ8IStPKGok0Iqr0F8KauSEa6/QUj6g7kC81+22GqI7sCNGr1QiZ4rL5J1p3EXjjz4FdLQ=="
     },
     "ms-nationalities": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "^7.0.1",
     "moment": "^2.27.0",
     "ms-countries": "^1.0.0",
-    "ms-email-domains": "^2.2.2",
+    "ms-email-domains": "^2.2.3",
     "ms-nationalities": "^1.0.1",
     "ms-organisations": "^1.5.0",
     "ms-uk-cities-and-towns": "^2.0.2",


### PR DESCRIPTION
updated ms-email-domains to v2.2.3 to whitelist "nctrust.co.uk" and "gwnedd.llyw.cymru"