### PR TITLE
SD-514 correct session-cookies on cookie page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dump.rdb
 .scannerwork/
 .nyc_output/
 .idea
+.DS_Store

--- a/apps/common/index.js
+++ b/apps/common/index.js
@@ -6,7 +6,8 @@ module.exports = {
       '/privacy': 'privacy',
       '/accessibility': 'accessibility',
       '/support-organisations': 'support-organisations',
-      '/designated-organisations': 'designated-organisations'
+      '/designated-organisations': 'designated-organisations',
+      '/cookies': 'cookies'
     },
     steps: {
       '/start': {

--- a/apps/common/translations/src/en/cookies.json
+++ b/apps/common/translations/src/en/cookies.json
@@ -1,0 +1,26 @@
+{
+  "session-cookies-table": {
+    "headers": [
+      "Name",
+      "Purpose",
+      "Expires"
+    ],
+    "rows": [
+      [
+        "modern-slavery.hof.sid",
+        "Stores a session ID and temporarily stores data you enter to enable you to make an application",
+        "When you close your browser"
+      ],
+      [
+        "hof-wizard-sc",
+        "Tells us when your session starts so we can tell you if it expires",
+        "When you close your browser"
+      ],
+      [
+        "hof-cookie-check",
+        "Tells us you have already allowed cookies so we don’t need to ask you again",
+        "When you close your browser"
+      ]
+    ]
+  }
+}

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -11,6 +11,7 @@
     "./apps/nrm",
     "./apps/feedback"
   ],
+  "getCookies": "false,",
   "session": {
     "name": "modern-slavery.hof.sid"
   },

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ app.use('/prompt-sheet-for-working-offline', (req, res) => {
   download.responseFile('/assets/documents', 'nrm-form-offline-v2-19-09-2019.pdf', res);
 });
 
-app.use((req, res, next) => {
+const addGenericLocals = (req, res, next) => {
   // Set HTML Language
   res.locals.htmlLang = 'en';
   // Set feedback and footer links
@@ -38,6 +38,16 @@ app.use((req, res, next) => {
     { path: '/terms-and-conditions', property: 'base.terms' },
     { path: '/accessibility', property: 'base.accessibility' },
   ];
+  next();
+};
+
+app.use((req, res, next) => addGenericLocals(req, res, next));
+
+app.use('/cookies', (req, res, next) => {
+  res.locals = Object.assign({}, res.locals, req.translate('cookies'));
+   if (res.locals['session-cookies-table'].rows[0][0] === 'hmbrp.sid') {
+     res.locals['session-cookies-table'].rows[0][0] = 'modern-slavery.hof.sid';
+   }
   next();
 });
 

--- a/index.js
+++ b/index.js
@@ -7,25 +7,11 @@ const busboyBodyParser = require('busboy-body-parser');
 const download = require('./download-file');
 const settings = require('./hof.settings');
 const path = require('path');
-const fs = require('fs');
 
 settings.routes = settings.routes.map(route => require(route));
 settings.views = path.resolve(__dirname, './apps/common/views');
 settings.root = __dirname;
 settings.start = false;
-
-// edit cookies.json from hof-template-partials so that the correct session cookies are shown on /cookies
-fs.readFile('node_modules/hof-template-partials/translations/src/en/cookies.json', 'utf8', (e, data) => {
-  const obj = JSON.parse(data);
-  obj['session-cookies-table'].rows[0][0] = 'modern-slavery.hof.sid';
-  fs.writeFile('node_modules/hof-template-partials/translations/src/en/cookies.json',
-      JSON.stringify(obj, null, 2), (err) => {
-        if (err) {
-          // eslint-disable-next-line no-console
-          console.err(err);
-        }
-      });
-});
 
 const app = hof(settings);
 

--- a/index.js
+++ b/index.js
@@ -7,11 +7,25 @@ const busboyBodyParser = require('busboy-body-parser');
 const download = require('./download-file');
 const settings = require('./hof.settings');
 const path = require('path');
+const fs = require('fs');
 
 settings.routes = settings.routes.map(route => require(route));
 settings.views = path.resolve(__dirname, './apps/common/views');
 settings.root = __dirname;
 settings.start = false;
+
+// edit cookies.json from hof-template-partials so that the correct session cookies are shown on /cookies
+fs.readFile('node_modules/hof-template-partials/translations/src/en/cookies.json', 'utf8', (e, data) => {
+  const obj = JSON.parse(data);
+  obj['session-cookies-table'].rows[0][0] = 'modern-slavery.hof.sid';
+  fs.writeFile('node_modules/hof-template-partials/translations/src/en/cookies.json',
+      JSON.stringify(obj, null, 2), (err) => {
+        if (err) {
+          // eslint-disable-next-line no-console
+          console.err(err);
+        }
+      });
+});
 
 const app = hof(settings);
 


### PR DESCRIPTION
# What
Session cookie was incorrectly showing as hmbrp.sid on the /cookies page. This update corrects this to modern-slavery.hof.sid

# How
-update to index.js to explicitly set modern slavery session cookie
-set getCookies to false in hof.settings.json
-add /cookies page to pages in apps.common