### PR TITLE
SD-707 Fix session expired from token email

### DIFF
--- a/apps/verify/behaviours/email-lookup-sender.js
+++ b/apps/verify/behaviours/email-lookup-sender.js
@@ -6,7 +6,7 @@ const NotifyClient = require('notifications-node-client').NotifyClient;
 const notifyClient = new NotifyClient(notifyApiKey);
 const templateId = config.govukNotify.templateUserAuthId;
 const appPath = require('../../nrm/index').baseUrl;
-const firstStep = '/start/';
+const firstStep = '/start';
 const tokenGenerator = require('../models/save-token');
 
 const getPersonalisation = (host, token) => {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node app.js",
+    "debug": "node --inspect app.js",
     "dev": "NODE_ENV=development hof-build watch",
     "test": "NODE_ENV=test npm-run-all test:unit lint",
     "test:unit": "_mocha",


### PR DESCRIPTION
## What?

Modern slavery sends an email to users with a token to verify the user and then be able to complete the form.  In the new version of HOF, when you click on a link, it brings up a session error page. This PR fixes the above issue

I've also added a script to debug the code in `package.json`

## Why?

Because a user has clicked on a link they should not be shown a session-error

## How?

* The issue is in `hof-form-wizard` and in the `req.path !== first`
`req.path` was returning `/start` but `first` was returning `/start/`
* Remove end slash from the first step in the journey from '/start/'
to `/start`

## Testing?

Locally