### PR TITLE
SD-642 gid cookie is not mentioned in cookie policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4754,9 +4754,9 @@
       }
     },
     "hof-template-partials": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/hof-template-partials/-/hof-template-partials-5.3.2.tgz",
-      "integrity": "sha512-ScFBQ9wsUGI+ySnFZH0N2W1oweG84ktQ/8XUlcTKiAwuzXp6tiUSfoBSnn3oiDOPL/RJUomAjQ3ptabcAZEZ9g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/hof-template-partials/-/hof-template-partials-5.3.3.tgz",
+      "integrity": "sha512-ntqisKqveINLKxbWRKSUzfhlD43DRyh6MuIzMiDfHFekFUuhfjaUxcv0acfuxNq9VfbEAAwcyj8s25+gFQP09A==",
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hof-build": "^1.6.0",
     "hof-component-date": "^1.4.0",
     "hof-model": "^3.1.2",
-    "hof-template-partials": "^5.3.2",
+    "hof-template-partials": "^5.3.3",
     "hof-theme-govuk": "^5.1.1",
     "hof-util-countries": "^1.0.0",
     "ioredis": "^4.0.0",


### PR DESCRIPTION
# What 
An update hof-template partials so that the gid cookie is displayed within the cookie policy

# Why
The table was missing the "_gid" tracking cookie

# How
-Updated hof-template-partials that includes information on the gid cookie

# Screenshot
<img width="706" alt="Screenshot 2021-04-06 at 17 45 41" src="https://user-images.githubusercontent.com/60218616/113748037-eb185780-96ff-11eb-8f71-608c1da67d20.png">