### PR TITLE
SD-118: Saving a report shows wrong due date of completion

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   - npm --loglevel warn install
   - npm run test
   when:
-    branch: [ master, features/* ]
+    branch: [ master, feature/* ]
     event: push
 
 - name: build_modern_slavery
@@ -21,7 +21,7 @@ steps:
   - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
   - docker build -t app-$${DRONE_COMMIT_SHA} .
   when:
-    branch: [ master, features/* ]
+    branch: [ master, feature/* ]
     event: push
 
 - name: image_to_quay

--- a/apps/nrm/behaviours/save-and-exit.js
+++ b/apps/nrm/behaviours/save-and-exit.js
@@ -1,12 +1,18 @@
 'use strict';
 const moment = require('moment');
+const config = require('../../../config');
+
+const calculateExpiryDate = createdAtDate => {
+  return moment(createdAtDate).add(config.reports.deletionTimeout, 'days')
+      .format('DD MMMM YYYY');
+};
 
 module.exports = superclass => class extends superclass {
 
   locals(req, res) {
     const superlocals = super.locals(req, res);
     const data = Object.assign({}, {
-      reportExpiration: moment(req.sessionModel.get('created_at')).format('DD MMMM YYYY'),
+      reportExpiration: calculateExpiryDate(req.sessionModel.get('created_at')),
       userEmail: req.sessionModel.get('user-email')
     });
     const locals = Object.assign({}, superlocals, data);

--- a/test/unit/nrm/behaviours/save-and-exit.test.js
+++ b/test/unit/nrm/behaviours/save-and-exit.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const reqres = require('reqres');
+const Behaviour = require('../../../../apps/nrm/behaviours/save-and-exit');
+const TestDate = 'Mon 05 Jul 2021 13:28:56 +0100';
+const TestDateFeb = 'Sat 29 Feb 2020 13:28:56 +0100';
+const CorrectDate = '02 August 2021';
+const CorrectDateFeb = '28 March 2020';
+const Route = 'save-and-exit';
+const UserEmail = 'mary-jane-parker@homeoffice.gov.uk';
+
+describe('/apps/nrm/behaviours/save-and-exit', () => {
+  it('exports a function', () => {
+    expect(Behaviour).to.be.a('function');
+  });
+
+  class Base {
+    locals() {}
+  }
+
+  let sessionModel;
+  let req;
+  let res;
+  let instance;
+  let SaveAndExit;
+
+  let superLocals = {
+    'route': Route,
+    'created_at': TestDate,
+    'user-email': UserEmail
+  };
+
+  const data = Object.assign({}, {
+    reportExpiration: CorrectDate,
+    userEmail: UserEmail
+  });
+
+  let locals = Object.assign({}, superLocals, data);
+
+  describe('locals()', () => {
+    beforeEach(() => {
+      sessionModel = {
+        get: sinon.stub(),
+        reset: sinon.stub()
+      };
+      req = reqres.req({ sessionModel });
+      res = reqres.res();
+      SaveAndExit = Behaviour(Base);
+      instance = new SaveAndExit();
+      sinon.stub(Base.prototype, 'locals').returns(locals);
+    });
+    afterEach(() => {
+      locals = {
+        'route': Route,
+        'created_at': TestDate,
+        'user-email': UserEmail
+      };
+
+      Base.prototype.locals.restore();
+    });
+
+    it('returns an extended locals with expiry date calculated', async() => {
+      const expected = {
+        'route': Route,
+        'created_at': TestDate,
+        'user-email': UserEmail,
+        'reportExpiration': CorrectDate,
+        'userEmail': UserEmail
+      };
+
+      req.sessionModel.get.withArgs('created_at').returns(TestDate);
+      req.sessionModel.get.withArgs('user-email').returns(UserEmail);
+
+      const result = instance.locals(req, res);
+      result.should.deep.equal(expected);
+      expect(sessionModel.reset).to.have.been.called;
+    });
+
+    it('returns an extended locals with expiry date calculated for 29th Feb', async() => {
+      const expected = {
+        'route': Route,
+        'created_at': TestDateFeb,
+        'user-email': UserEmail,
+        'reportExpiration': CorrectDateFeb,
+        'userEmail': UserEmail
+      };
+      // eslint-disable-next-line camelcase
+      locals.created_at = TestDateFeb;
+
+      req.sessionModel.get.withArgs('created_at').returns(TestDateFeb);
+      req.sessionModel.get.withArgs('user-email').returns(UserEmail);
+
+      const result = instance.locals(req, res);
+      result.should.deep.equal(expected);
+      expect(sessionModel.reset).to.have.been.called;
+    });
+
+    it('returns an Invalid date when given an empty created_at date', async() => {
+      const expected = {
+        'route': Route,
+        'created_at': '',
+        'user-email': UserEmail,
+        'reportExpiration': 'Invalid date',
+        'userEmail': UserEmail
+      };
+      // eslint-disable-next-line camelcase
+      locals.created_at = '';
+
+      req.sessionModel.get.withArgs('created_at').returns('');
+      req.sessionModel.get.withArgs('user-email').returns(UserEmail);
+
+      const result = instance.locals(req, res);
+      result.should.deep.equal(expected);
+      expect(sessionModel.reset).to.have.been.called;
+    });
+
+
+    it('resets the session', () => {
+      instance.locals(req, res);
+      expect(sessionModel.reset).to.have.been.called;
+    });
+
+    it('gets the users email and report creation date from the previous page', () => {
+      instance.locals(req, res);
+      expect(sessionModel.get).to.have.been.calledWith('user-email');
+      expect(sessionModel.get).to.have.been.calledWith('created_at');
+    });
+  });
+});


### PR DESCRIPTION
**Jira Ticket:** https://collaboration.homeoffice.gov.uk/jira/browse/SD-118

**Changes**

- Changed and refactored save-and-exit.js to include calculation for end date instead of start date on the report.
- Added unit tests (save-and-exit.test.js) for the expiry date calculation. 
- Corrected features to feature typo error in drone.yml
- Tested locally, and end date is now showing start date plus 28 days. 

**Screenshot**

- Today (7 June 2021) plus 28 Days (5 July 2021):
![image](https://user-images.githubusercontent.com/55537927/120996916-abf99780-c77e-11eb-8b53-00a2c1da6f1d.png)





