### PR TITLE
SD-837 alter submission to icasework for jursidiction

### DIFF
--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -18,7 +18,7 @@ module.exports = data => {
     'Email, Post' : _.upperFirst(data['pv-contact-details']);
   response['Customer.Alias'] = data['pv-name-nickname'];
   if (data['fr-location']) {
-    response['Case.Jurisdiction'] = data['fr-location'].toUpperCase().replace(' ', '');
+    response['Case.Jurisdiction'] = data['fr-location'].toUpperCase().replace(' ', '').replace('-', '');
   }
   if (data['pv-dob']) {
     response['Customer.Custom7'] = 'Yes';


### PR DESCRIPTION
## What?
A change to submission.js to remove '-'

## Why?
This was affecting the way holidays were calculated if the user selected 'Northern Ireland'
We passed the jurisdiction as 'NORTHERN-IRELAND' when iCasework is looking for 'NORTHERNIRELAND'

## How?
changed where the Jurisdiction is set in the iCasework submission to remove '-' 

## Testing?
Will need to be tested in prod
