### PR TITLE
Updated ms-email-domains to 2.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -490,9 +490,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
+      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -1508,9 +1508,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -1625,28 +1625,9 @@
       }
     },
     "connect-redis": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-3.4.2.tgz",
-      "integrity": "sha512-ozA1Z0GDnsCJECfNyNJOqPuW3Fk43fUbKC65Sa/V9hkCBNtXsFU2xtTOVsQGUsflpywuJMgGOV4xrnKzIPFqvA==",
-      "requires": {
-        "debug": "^4.1.1",
-        "redis": "^2.8.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-5.2.0.tgz",
+      "integrity": "sha512-wcv1lZWa2K7RbsdSlrvwApBQFLQx+cia+oirLIeim0axR3D/9ZJbHdeTM/j8tJYYKk34dVs2QPAuAqcIklWD+Q=="
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -2132,11 +2113,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -3184,29 +3160,29 @@
       }
     },
     "express-session": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
-      "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.2.tgz",
+      "integrity": "sha512-mPcYcLA0lvh7D4Oqr5aNJFMtBMKPLl++OKKxkHzZ0U0oDq1rpKBnkR5f5vCHR26VeArlTOEF9td4x5IjICksRQ==",
       "requires": {
-        "cookie": "0.4.0",
+        "cookie": "0.4.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-headers": "~1.0.2",
         "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.0",
+        "safe-buffer": "5.2.1",
         "uid-safe": "~2.1.5"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         }
       }
     },
@@ -4326,12 +4302,12 @@
       }
     },
     "hof": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/hof/-/hof-18.2.2.tgz",
-      "integrity": "sha512-yh2zz9nfX0L9nF9EmdXiOXjyXG0bNJnUdU7SDUD3kq0HErRDWkeWekB3zKNqrCA85FyhuBwYfJiVsEaAMvG5cQ==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/hof/-/hof-18.3.0.tgz",
+      "integrity": "sha512-L+3gONeCmmW6thWuhEV9S7+ZXaU60INHcKvkgaQ0Q7PxVUAcDcj0462ZSnzedKViyhegYZLCnDP+P3Nb5dVsFw==",
       "requires": {
         "body-parser": "^1.15.1",
-        "connect-redis": "^3.1.0",
+        "connect-redis": "^5.2.0",
         "cookie-parser": "^1.4.1",
         "deprecate": "^1.0.0",
         "express": "^4.13.4",
@@ -4342,13 +4318,13 @@
         "hof-form-wizard": "^5.1.1",
         "hof-middleware": "^2.2.3",
         "hof-middleware-markdown": "^2.0.0",
-        "hof-template-mixins": "^5.3.2",
+        "hof-template-mixins": "^6.0.2",
         "hof-theme-govuk": "^5.2.4",
         "hogan-express-strict": "^0.5.4",
         "i18n-future": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "morgan": "^1.10.0",
-        "redis": "^2.6.0-2",
+        "redis": "^3.1.2",
         "winston": "^3.3.3"
       }
     },
@@ -4422,9 +4398,9 @@
       }
     },
     "hof-form-controller": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/hof-form-controller/-/hof-form-controller-6.2.2.tgz",
-      "integrity": "sha512-VFNptOJAfjbfQdDkFNrwiPMGBjnZrvdMe8V0HokZ8OtR5LMsy2IVPtFyvgS9xgHfbF/zYyMZ8MZIiHjcsZibxA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/hof-form-controller/-/hof-form-controller-6.4.0.tgz",
+      "integrity": "sha512-o55ZDs75fHHel7+ftLNE516IeY+PtTfE2EnHa0hmLZs00CoRCnHz5IcYtV9ifj2PAbtAiWJKzJ6NFBoqtuKRPA==",
       "requires": {
         "debug": "^2.6.9",
         "deprecate": "^1.0.0",
@@ -4437,7 +4413,15 @@
         "lodash": "^4.17.15",
         "mixwith": "^0.1.1",
         "moment": "^2.24.0",
-        "mustache": "^2.3.0"
+        "mustache": "^2.3.0",
+        "underscore": "^1.13.1"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+          "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+        }
       }
     },
     "hof-form-wizard": {
@@ -4526,15 +4510,15 @@
       }
     },
     "hof-template-mixins": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/hof-template-mixins/-/hof-template-mixins-5.3.2.tgz",
-      "integrity": "sha512-F5GVwQ8gx6BNv0xJ5ooiAhBBSm/9b7SCoTOJpEk9bhMjMG8I0+nRBrbUm1No/cXZpatlBXgDPdnB6n+0/4g7dQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hof-template-mixins/-/hof-template-mixins-6.0.2.tgz",
+      "integrity": "sha512-hVzi01geGtTP+3u0Zai6R//BRMXpiojX3E6e2G/iUcRbpvfXyHmqlDNMou7pdhswyIL6L1nrgRBc9GDO7IEaaw==",
       "requires": {
         "deprecate": "^1.0.0",
         "express": "^4.15.2",
         "hogan.js": "^3.0.2",
         "moment": "^2.13.0",
-        "underscore": "^1.8.3"
+        "underscore": "^1.12.1"
       }
     },
     "hof-template-partials": {
@@ -5225,9 +5209,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.5",
@@ -5659,9 +5643,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.9.17",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.17.tgz",
-      "integrity": "sha512-ElJki901OynMg1l+evooPH1VyHrECuLqpgc12z2BkK25dFU5lUKTuMHEYV2jXxvtns/PIuJax56cBeoSK7ANow=="
+      "version": "1.9.34",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.34.tgz",
+      "integrity": "sha512-gHTNU9xTtVgSp30IDX/57W4pETMXDIYXFfwEOJVXiYosiY7Hc7ogJwlBjOqlCcU04X0aA8DT57hdwUC1sJBJnA=="
     },
     "liftoff": {
       "version": "3.1.0",
@@ -6337,9 +6321,9 @@
       "integrity": "sha512-t+wlqwKFJl0yUNtwLbUWBd0irrsBBrTbHAK22dDN9Ut9H0zOf6iVKNz0DAINDtE2rgf+8hmzGt7SSmXAN7Im/A=="
     },
     "ms-email-domains": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.4.tgz",
-      "integrity": "sha512-btJ/6wHpvtKjN5mV14K9oV/a0Oiws+VBMBK7dvmvboBC7ewvmSg2rTOdCfkWe6Tqb0ZY7+nwjlG5kSePay6jHg=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/ms-email-domains/-/ms-email-domains-2.2.5.tgz",
+      "integrity": "sha512-s8a8ryUGB2Sojg5JZc60JmdJHyG8azfq6PhznGcO10daJT3d3Bs3Dh589XsTtjM/RIFR9FuO5u0lWyDQHrpBGw=="
     },
     "ms-nationalities": {
       "version": "1.0.1",
@@ -8364,13 +8348,14 @@
       }
     },
     "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
       }
     },
     "redis-commands": {
@@ -8384,9 +8369,12 @@
       "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "referrer-policy": {
       "version": "1.2.0",
@@ -10331,9 +10319,9 @@
       }
     },
     "yargs-parser": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-      "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+      "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "^7.0.1",
     "moment": "^2.27.0",
     "ms-countries": "^1.0.0",
-    "ms-email-domains": "^2.2.4",
+    "ms-email-domains": "^2.2.5",
     "ms-nationalities": "^1.0.1",
     "ms-organisations": "^1.5.1",
     "ms-uk-cities-and-towns": "^2.0.2",


### PR DESCRIPTION
What
Updated ms-email-domains to 2.2.5

Why
Deleted nccgroup email domains that were used for ITHC and are not required anymore

How
Removed from email domain list

Test
Submitting a work email address to access the service with a deleted email domain will produce an ‘Email not recognised’ error
