### PR TITLE
NRM-91 bugfix download prompt sheet not found error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dump.rdb
 .DS_Store
 coverage
 anchore-reports/
+acceptance-test/temp-downloads/

--- a/acceptance-test/test-config.js
+++ b/acceptance-test/test-config.js
@@ -5,6 +5,7 @@ module.exports = {
     START_HOME_BUTTON: '#content > div > form > div > div.govuk-grid-column-two-thirds > input',
     START_REPORT: '#content > div > form > div > div > input',
     CONTINUE_BUTTON: '#content > div > form > input.button',
+    DOWNLOAD_REPORT: '#paper-version-download',
     REFERENCE_INPUT: '#reference',
     EMAIL_INPUT: '#user-email',
     ORGANISATION_INPUT: '#user-organisation',

--- a/acceptance-test/user-pathways/happy-path/happy-path.test.js
+++ b/acceptance-test/user-pathways/happy-path/happy-path.test.js
@@ -288,7 +288,7 @@ describe.only('User path(s)', () => {
     }
   }).timeout(defaultTimeout);
 
-  it.only('downloads the prompt sheet', async () => {
+  it('downloads the prompt sheet', async () => {
     let fileExists;
     const filePath = `${downloadPath}/${promptSheet}`
     try {
@@ -299,15 +299,9 @@ describe.only('User path(s)', () => {
 
       await clickSelector(page, DOWNLOAD_REPORT);
       await clickSelector(page, DOWNLOAD_REPORT);
-      await fs.access(filePath, fs.F_OK, (err) => {
-        if (err) {
-          fileExists = false;
-        } else {
-          fileExists = true;
-        }
-        expect(fileExists).to.deep.equal(true);
-      })
-
+      const pageContent = await page.content();
+      const result = pageContent.includes('Not found')
+      expect(result).to.be.false;
     } catch (err) {
       throw new Error(err);
     }

--- a/acceptance-test/user-pathways/happy-path/happy-path.test.js
+++ b/acceptance-test/user-pathways/happy-path/happy-path.test.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-undef */
 'use strict';
 const path = require('path');
-const fs = require('fs');
 const downloadPath = path.resolve('./acceptance-test/temp-downloads');
-const promptSheet = require('../../../config').promptSheet;
 const bootstrap = require('../../bootstrap/bootstrap');
 const config = require('../../test-config');
 const pageActions = require('../util/page-actions');
@@ -289,8 +287,6 @@ describe.only('User path(s)', () => {
   }).timeout(defaultTimeout);
 
   it('downloads the prompt sheet', async () => {
-    let fileExists;
-    const filePath = `${downloadPath}/${promptSheet}`
     try {
       await page._client.send('Page.setDownloadBehavior', {
         behavior: 'allow',
@@ -300,7 +296,7 @@ describe.only('User path(s)', () => {
       await clickSelector(page, DOWNLOAD_REPORT);
       await clickSelector(page, DOWNLOAD_REPORT);
       const pageContent = await page.content();
-      const result = pageContent.includes('Not found')
+      const result = pageContent.includes('Not found');
       expect(result).to.be.false;
     } catch (err) {
       throw new Error(err);

--- a/acceptance-test/user-pathways/happy-path/happy-path.test.js
+++ b/acceptance-test/user-pathways/happy-path/happy-path.test.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-undef */
 'use strict';
+const path = require('path');
+const fs = require('fs');
+const downloadPath = path.resolve('./acceptance-test/temp-downloads');
+const promptSheet = require('../../../config').promptSheet;
 const bootstrap = require('../../bootstrap/bootstrap');
 const config = require('../../test-config');
 const pageActions = require('../util/page-actions');
@@ -8,6 +12,7 @@ const { clickSelector, focusThenType, navigateTo } = pageActions;
 const {
   START_REPORT,
   CONTINUE_BUTTON,
+  DOWNLOAD_REPORT,
   REFERENCE_INPUT,
   ORGANISATION_INPUT,
   EMAIL_INPUT,
@@ -278,6 +283,31 @@ describe.only('User path(s)', () => {
     try {
       await verifyUser();
       await completeForm1of2('adult', false);
+    } catch (err) {
+      throw new Error(err);
+    }
+  }).timeout(defaultTimeout);
+
+  it.only('downloads the prompt sheet', async () => {
+    let fileExists;
+    const filePath = `${downloadPath}/${promptSheet}`
+    try {
+      await page._client.send('Page.setDownloadBehavior', {
+        behavior: 'allow',
+        downloadPath: downloadPath
+      });
+
+      await clickSelector(page, DOWNLOAD_REPORT);
+      await clickSelector(page, DOWNLOAD_REPORT);
+      await fs.access(filePath, fs.F_OK, (err) => {
+        if (err) {
+          fileExists = false;
+        } else {
+          fileExists = true;
+        }
+        expect(fileExists).to.deep.equal(true);
+      })
+
     } catch (err) {
       throw new Error(err);
     }

--- a/apps/common/views/paper-version-download.html
+++ b/apps/common/views/paper-version-download.html
@@ -10,7 +10,7 @@
   <p class="govuk-body">{{#t}}pages.paper-version-download.paragraph-3{{/t}}</p>
   <p class="govuk-body">{{#t}}pages.paper-version-download.paragraph-4{{/t}}</p>
 <div class="govuk-!-padding-bottom-3"></div>
-  <a href="prompt-sheet-for-working-offline" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">{{#t}}pages.paper-version-download.download-button{{/t}}</a>
+  <a href="prompt-sheet-for-working-offline" id="paper-version-download" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">{{#t}}pages.paper-version-download.download-button{{/t}}</a>
   <div class="govuk-!-padding-bottom-1"></div>
 </fieldset>
 {{/page-content}}

--- a/apps/common/views/start.html
+++ b/apps/common/views/start.html
@@ -41,7 +41,7 @@
             </a>
           </li>
           <li>
-            <a href="paper-version-download">
+            <a href="paper-version-download" id='paper-version-download'>
               {{#t}}pages.start.aside-link-text-3{{/t}}
             </a>
           </li>

--- a/config.js
+++ b/config.js
@@ -47,5 +47,6 @@ module.exports = {
     templateFeedback: process.env.TEMPLATE_FEEDBACK || '92b314e9-8ed5-4762-a8e2-7f208cdf3836',
     caseworkerEmail: process.env.CASEWORKER_EMAIL || 'serviceopstesting@digital.homeoffice.gov.uk',
     feedbackEmail: process.env.FEEDBACK_EMAIL || 'serviceopstesting@digital.homeoffice.gov.uk'
-  }
+  },
+  promptSheet: 'nrm-form-offline-v2-19-09-2019.pdf'
 };

--- a/lib/download-file.js
+++ b/lib/download-file.js
@@ -1,25 +1,24 @@
 /* eslint-disable node/no-deprecated-api */
 'use strict';
 
-const fs = require('fs');
+const { existsSync } = require('fs');
 const path = require('path');
 const download = exports;
 
 download.responseFile = async (basePath, fileName, res) => {
   const fullFileName = path.join(basePath, fileName);
-  const directory = `${__dirname}${fullFileName}`;
+  const removeLibFromDirectory = __dirname.substring(0, __dirname.lastIndexOf('/'))
+  const directory = `${removeLibFromDirectory}${fullFileName}`;
 
-  await fs.exists(directory, async exist => {
-    if (exist) {
-      const filename = path.basename(fullFileName);
+  if (existsSync(directory)) {
+    const filename = path.basename(fullFileName);
 
-      await res.setHeader('Content-Disposition', 'attachment; filename=' + filename);
-      await res.setHeader('Content-Transfer-Encoding', 'binary');
-      await res.setHeader('Content-Type', 'application/octet-stream');
+    await res.setHeader('Content-Disposition', 'attachment; filename=' + filename);
+    await res.setHeader('Content-Transfer-Encoding', 'binary');
+    await res.setHeader('Content-Type', 'application/octet-stream');
 
-      await res.sendFile(directory);
-    } else {
-      await res.sendStatus(404);
-    }
-  });
+    await res.sendFile(directory);
+  } else {
+    await res.sendStatus(404);
+  }
 };

--- a/lib/download-file.js
+++ b/lib/download-file.js
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-deprecated-api */
 'use strict';
 
 const { existsSync } = require('fs');
@@ -7,7 +6,7 @@ const download = exports;
 
 download.responseFile = async (basePath, fileName, res) => {
   const fullFileName = path.join(basePath, fileName);
-  const removeLibFromDirectory = __dirname.substring(0, __dirname.lastIndexOf('/'))
+  const removeLibFromDirectory = __dirname.substring(0, __dirname.lastIndexOf('/'));
   const directory = `${removeLibFromDirectory}${fullFileName}`;
 
   if (existsSync(directory)) {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "license": "MIT",
   "scripts": {
     "start": "node server.js",
-    "debug": "node -r dotenv/config --inspect app.js",
     "start:dev": "ALLOW_SKIP=true SKIP_EMAIL=sas-hof-test@digital.homeoffice.gov.uk hof-build watch",
+    "debug": "node -r dotenv/config --inspect server.js",
+    "devenv": "hof-build watch --env",
     "test": "NODE_ENV=test yarn run test:unit && yarn run test:lint",
     "test:unit": "nyc _mocha \"test/_unit/**/*.spec.js\"",
     "test:docker-acceptance": "env BROWSER_TYPE=remote _mocha --recursive acceptance-test/user-pathways",

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const hof = require('hof');
 const download = require('./lib/download-file');
 const settings = require('./hof.settings');
 const path = require('path');
+const promptSheet = require('./config').promptSheet;
 
 const sessionCookiesTable = require('./apps/common/translations/src/en/cookies.json');
 
@@ -15,7 +16,7 @@ const app = hof(settings);
 
 // Downloads the offline form to client side
 app.use('/prompt-sheet-for-working-offline', (req, res) => {
-  download.responseFile('/assets/documents', 'nrm-form-offline-v2-19-09-2019.pdf', res);
+  download.responseFile('/assets/documents', promptSheet, res);
 });
 
 const addGenericLocals = (req, res, next) => {


### PR DESCRIPTION
## What?

* When you attempt to download the prompt sheet it comes back as a 404 not found. This is because the code for the file was removed to a lib directory which impacts on the location of the file
* this lib has been removed from the path to address this issue

## Testing?

Locally, I will wait for the branch to be setup before testing