### PR TITLE
NRM-95: Add automatic referral for application if victim is under 18 …

### DIFF
--- a/apps/nrm/behaviours/next-steps/page-custom-next-steps.js
+++ b/apps/nrm/behaviours/next-steps/page-custom-next-steps.js
@@ -123,6 +123,7 @@ module.exports = {
     let nextStep;
 
     if (req.sessionModel.get('pv-under-age') !== 'no') {
+      req.sessionModel.set('pv-want-to-submit-nrm', 'yes');
       nextStep = '/nrm/local-authority-contacted-about-child';
     } else {
       nextStep = '/nrm/pv-under-age-at-time-of-exploitation';


### PR DESCRIPTION
…into session

## What?
Add session data when victim under 18

## Why?
So that the form is aware of the application being automatically a referral so information entered by the first responder is included on the summary page

## How?
## Testing?
## Screenshots (optional)
## Anything Else?
