### PR TITLE
Reduce Icasework resolver replicas to 1

### DIFF
--- a/kube/icasework/icasework-resolver-deployment.yml
+++ b/kube/icasework/icasework-resolver-deployment.yml
@@ -8,11 +8,7 @@ metadata:
   name: icasework-resolver
   {{ end }}
 spec:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
   replicas: 1
-  {{ else }}
-  replicas: 2
-  {{ end }}
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What?
Reduce Icasework resolver replicas to 1
## Why?
We believe having two resolvers may be causing issues with duplication in production
## How?
Reduce replicas to 1 in resolver deployment
## Testing?
## Screenshots (optional)
## Anything Else?
