### PR TITLE
Schedule downtime with confirmation page warning

### DIFF
--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -288,6 +288,7 @@
   },
   "confirmation": {
     "header": "Confirmation",
+    "casework-downtime-alert": "ATTENTION. The caseworking system has scheduled downtime this weekend. Reports submitted after 5pm on friday 14th will not receive confirmation until the morning of Monday 17th",
     "dtn-message": "Duty to Notify (DtN) sent",
     "nrm-message": "NRM referral sent",
     "paragraph-1": "You will shortly receive a confirmation email with a reference number. You will also receive a copy of your report for your records.",

--- a/apps/nrm/views/confirmation.html
+++ b/apps/nrm/views/confirmation.html
@@ -1,6 +1,7 @@
 {{<partials-page}}
 {{$back}}<a class="link-back" href="/nrm/reports">{{#t}}buttons.back-to-reports{{/t}}</a><br>{{/back}}
 {{$page-content}}
+<div class="govuk-error-message">{{#t}}pages.confirmation.casework-downtime-alert{{/t}}</div>
 <div class="govuk-grid-row">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">

--- a/kube/icasework/icasework-resolver-deployment.yml
+++ b/kube/icasework/icasework-resolver-deployment.yml
@@ -6,6 +6,8 @@ metadata:
   name: icasework-resolver-{{ .DRONE_SOURCE_BRANCH }}
   {{ else }}
   name: icasework-resolver
+  annotations:
+    downscaler/downtime: Sat-Sun 00:00-24:00 Europe/London,Fri-Fri 17:00-24:00 Europe/London
   {{ end }}
 spec:
   replicas: 1


### PR DESCRIPTION
## What?
Scheduled downtime for iCasework resolver with Warning on confirmation page

## Why?
iCasework is undergoing works this saturday. This will leave all submitted reports in the SQS queue until the resolver is scaled back up at midnight Monday morning.

## How?
Add annotation to deployment file to schedule downtime.
Warning added to confirmation page

## Testing?
## Screenshots (optional)
## Anything Else?
