### PR TITLE
Schedule downtime with confirmation page warning

### DIFF
--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -288,7 +288,7 @@
   },
   "confirmation": {
     "header": "Confirmation",
-    "casework-downtime-alert": "ATTENTION. The caseworking system has scheduled downtime this weekend. Reports submitted after 5pm on friday 14th will not receive confirmation until the morning of Monday 17th",
+    "casework-downtime-alert": "ATTENTION. The caseworking system has scheduled downtime this weekend. Reports submitted after 5pm on Friday 14th will not receive confirmation until the morning of Monday 17th",
     "dtn-message": "Duty to Notify (DtN) sent",
     "nrm-message": "NRM referral sent",
     "paragraph-1": "You will shortly receive a confirmation email with a reference number. You will also receive a copy of your report for your records.",

--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -288,6 +288,7 @@
   },
   "confirmation": {
     "header": "Confirmation",
+    "casework-downtime-alert": "ATTENTION. The caseworking system has scheduled downtime this weekend. Reports submitted after 5pm on friday 14th will not receive confirmation until the morning of Monday 17th",
     "dtn-message": "Duty to Notify (DtN) sent",
     "nrm-message": "NRM referral sent",
     "paragraph-1": "You will shortly receive a confirmation email with a reference number. You will also receive a copy of your report for your records.",

--- a/apps/nrm/views/confirmation.html
+++ b/apps/nrm/views/confirmation.html
@@ -1,6 +1,7 @@
 {{<partials-page}}
 {{$back}}<a class="link-back" href="/nrm/reports">{{#t}}buttons.back-to-reports{{/t}}</a><br>{{/back}}
 {{$page-content}}
+<div class="govuk-error-message">{{#t}}pages.confirmation.casework-downtime-alert{{/t}}</div>
 <div class="govuk-grid-row">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">

--- a/kube/icasework/icasework-resolver-deployment.yml
+++ b/kube/icasework/icasework-resolver-deployment.yml
@@ -6,6 +6,8 @@ metadata:
   name: icasework-resolver-{{ .DRONE_SOURCE_BRANCH }}
   {{ else }}
   name: icasework-resolver
+  annotations:
+    downscaler/downtime: Sat-Sun 00:00-24:00 Europe/London,Fri-Fri 17:00-24:00 Europe/London
   {{ end }}
 spec:
   replicas: 1

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "license": "MIT",
   "scripts": {
     "start": "node server.js",
-    "start:dev": "ALLOW_SKIP=true SKIP_EMAIL=sas-hof-test@digital.homeoffice.gov.uk hof-build watch",
+    "start:dev": " ALLOW_SKIP=true SKIP_EMAIL=sas-hof-test@digital.homeoffice.gov.uk hof-build watch",
     "debug": "node -r dotenv/config --inspect server.js",
-    "dev": "ALLOW_SKIP=true SKIP_EMAIL=sas-hof-test@digital.homeoffice.gov.uk hof-build watch --env",
+    "dev": "NODE_ENV=production ALLOW_SKIP=true SKIP_EMAIL=sas-hof-test@digital.homeoffice.gov.uk hof-build watch --env",
     "test": "NODE_ENV=test yarn run test:unit && yarn run test:lint",
     "test:unit": "nyc _mocha \"test/_unit/**/*.spec.js\"",
     "test:docker-acceptance": "env BROWSER_TYPE=remote _mocha --recursive acceptance-test/user-pathways",
@@ -35,7 +35,7 @@
   "dependencies": {
     "accessible-autocomplete": "^2.0.2",
     "govuk-frontend": "^2.7.0",
-    "hof": "^19.11.23",
+    "hof": "^19.11.25",
     "ioredis": "^4.0.0",
     "jquery": "^3.3.1",
     "knex": "^0.95.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,12 +1311,12 @@ convert-source-map@~1.1.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
   integrity sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=
 
-cookie-parser@^1.4.1:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
-  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
+cookie-parser@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
+  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
   dependencies:
-    cookie "0.4.0"
+    cookie "0.4.1"
     cookie-signature "1.0.6"
 
 cookie-signature@1.0.6:
@@ -2420,7 +2420,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.7, glob@^7.1.0, glob@^7.1.3, glob@^7.1.7:
+glob@7.1.7, glob@^7.1.0, glob@^7.1.3:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -2443,7 +2443,7 @@ glob@^5.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2634,10 +2634,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^19.11.23:
-  version "19.11.23"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-19.11.23.tgz#f4ad20e5941d5f93d9858b99fab3d1c916675b2d"
-  integrity sha512-7eEz0N+HoJaRQb1cvoX8CJFKV8xEBUel4XXlQiPOgw+0EiuI0/ATB1u0nNT8UFqd7+HduinkElgRmSZWklZFUg==
+hof@^19.11.25:
+  version "19.11.25"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-19.11.25.tgz#5b35427701dc4567c4ea44d443d4c42cc76a700f"
+  integrity sha512-TLiLcR8nJS+m+kz9D5LDU6PM1AWm+Cjm6izAv5d3pCwarkaoqJm1J3+65AxOa6tfW9hZiXQ561GGO6TaiEfYkA==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -2647,7 +2647,7 @@ hof@^19.11.23:
     chalk "^2.0.0"
     chokidar "^3.4.0"
     connect-redis "^5.2.0"
-    cookie-parser "^1.4.1"
+    cookie-parser "^1.4.6"
     cp "^0.2.0"
     csrf "^3.0.2"
     debug "^4.3.1"
@@ -2659,7 +2659,7 @@ hof@^19.11.23:
     express-partial-templates "^0.2.0"
     express-session "^1.13.0"
     findup "^0.1.5"
-    glob "^7.1.7"
+    glob "^7.2.0"
     govuk-elements-sass "^3.1.3"
     govuk_template_mustache "^0.26.0"
     helmet "^3.22.0"
@@ -2669,9 +2669,9 @@ hof@^19.11.23:
     i18n-future "^2.0.0"
     i18n-lookup "^0.1.0"
     is-pdf "^1.0.0"
-    libphonenumber-js "^1.9.34"
+    libphonenumber-js "^1.9.37"
     lodash "^4.17.21"
-    markdown-it "^12.2.0"
+    markdown-it "^12.3.2"
     minimatch "^3.0.3"
     minimist "^1.2.0"
     mixwith "^0.1.1"
@@ -3389,10 +3389,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libphonenumber-js@^1.9.34:
-  version "1.9.42"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.42.tgz#41f41d540f89b6e3fd36de7120ddb57b3a468c77"
-  integrity sha512-UBtU0ylpZPKPT8NLIyQJWj/DToMFxmo3Fm5m6qDc0LATvf0SY0qUhaurCEvukAB9Fo+Ia2Anjzqwoupaa64fXg==
+libphonenumber-js@^1.9.37:
+  version "1.9.44"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz#d036364fe4c1e27205d1d283c7bf8fc25625200b"
+  integrity sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g==
 
 linkify-it@^3.0.1:
   version "3.0.2"
@@ -3553,10 +3553,10 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
-markdown-it@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.2.0.tgz#091f720fd5db206f80de7a8d1f1a7035fd0d38db"
-  integrity sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==
+markdown-it@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
   dependencies:
     argparse "^2.0.1"
     entities "~2.1.0"


### PR DESCRIPTION
## What?
Scheduled downtime for iCasework resolver with Warning on confirmation page
## Why?
iCasework is undergoing works this saturday. This will leave all submitted reports in the SQS queue until the resolver is scaled back up at midnight Monday morning.
## How?
Add annotation to deployment file to schedule downtime.
Warning added to confirmation page
## Testing?
## Screenshots (optional)
## Anything Else?
