### PR TITLE
Remove downtime and guidance

### DIFF
--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -288,7 +288,6 @@
   },
   "confirmation": {
     "header": "Confirmation",
-    "casework-downtime-alert": "ATTENTION. The caseworking system has scheduled downtime this weekend. Reports submitted after 5pm on Friday 14th will not receive confirmation until the morning of Monday 17th",
     "dtn-message": "Duty to Notify (DtN) sent",
     "nrm-message": "NRM referral sent",
     "paragraph-1": "You will shortly receive a confirmation email with a reference number. You will also receive a copy of your report for your records.",

--- a/apps/nrm/views/confirmation.html
+++ b/apps/nrm/views/confirmation.html
@@ -1,7 +1,6 @@
 {{<partials-page}}
 {{$back}}<a class="link-back" href="/nrm/reports">{{#t}}buttons.back-to-reports{{/t}}</a><br>{{/back}}
 {{$page-content}}
-<div class="govuk-error-message">{{#t}}pages.confirmation.casework-downtime-alert{{/t}}</div>
 <div class="govuk-grid-row">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">

--- a/kube/icasework/icasework-resolver-deployment.yml
+++ b/kube/icasework/icasework-resolver-deployment.yml
@@ -6,8 +6,6 @@ metadata:
   name: icasework-resolver-{{ .DRONE_SOURCE_BRANCH }}
   {{ else }}
   name: icasework-resolver
-  annotations:
-    downscaler/downtime: Sat-Sun 00:00-24:00 Europe/London,Fri-Fri 17:00-24:00 Europe/London
   {{ end }}
 spec:
   replicas: 1


### PR DESCRIPTION
## What?
Reverting the scheduled downtime and removing the guidance relating to it
## Why?
Scheduled downtime has passed and is no longer needed
## How?
revert changes to icasework resolver deployment
remove guidance relating to it on confirmation page

