### PR TITLE
Remove UK from overseas option

### DIFF
--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const ukCitiesAndTowns = require('ms-uk-cities-and-towns');
 const ukRegions = require('ms-uk-regions');
-const countries = require('ms-countries');
+const countriesExcludingUK = require('../util/filtered-countries').countriesExcludingUK;
 const ukPoliceForces = require('ms-uk-police-forces');
 const dateComponent = require('hof').components.date;
 const ukLocalAuthorities = require('ms-uk-local-authorities');
@@ -224,7 +224,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-2': {
     mixin: 'select',
@@ -232,7 +232,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-3': {
     mixin: 'select',
@@ -240,7 +240,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-4': {
     mixin: 'select',
@@ -248,7 +248,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-5': {
     mixin: 'select',
@@ -256,7 +256,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-6': {
     mixin: 'select',
@@ -264,7 +264,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-7': {
     mixin: 'select',
@@ -272,7 +272,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-8': {
     mixin: 'select',
@@ -280,7 +280,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-9': {
     mixin: 'select',
@@ -288,7 +288,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-overseas-country-10': {
     mixin: 'select',
@@ -296,7 +296,7 @@ module.exports = {
     options: [{
       value: '',
       label: 'fields.where-exploitation-happened-overseas-country.options.null'
-    }].concat(countries)
+    }].concat(countriesExcludingUK)
   },
   'where-exploitation-happened-other-overseas-other-location': {
     mixin: 'textarea',

--- a/apps/nrm/util/filtered-countries.js
+++ b/apps/nrm/util/filtered-countries.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const countries = require('ms-countries');
+
+const countriesExcludingUK = countries.filter(country => country.value !== 'United Kingdom');
+
+module.exports = {
+  countriesExcludingUK
+};


### PR DESCRIPTION
## What?
Removed UK as one of the overseas options on /where-exploitation-happened-overseas

## Why?
Request from stakeholder. There is a separate option for the UK, and it does not need to appear in the overseas options

## How?
Filter the countries array that was being used to exclude the UK 

## Testing?
Local testing on /nrm/where-exploitation-happened-overseas

## Screenshots (optional)
## Anything Else? (optional)
