### PR TITLE
NRM-133: update ms-email-domains to allow capital letters

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "accessible-autocomplete": "^2.0.2",
     "govuk-frontend": "^2.7.0",
-    "hof": "^19.13.6",
+    "hof": "^19.13.11",
     "ioredis": "^4.0.0",
     "jquery": "^3.3.1",
     "knex": "^0.95.11",

--- a/test/_unit/common/validators.spec.js
+++ b/test/_unit/common/validators.spec.js
@@ -36,4 +36,14 @@ describe('apps/common/validators', () => {
     ].map(validators.isValidEmail);
     result.should.not.contain(false);
   });
+
+  it('should accept emails with domain portions with capital letters', () => {
+    const result = [
+      'test@Example.com',
+      'test@examplE.gov.uk',
+      'test@subdomain.exaMple.com',
+      'test@example.InternaTional'
+    ].map(validators.isValidEmail);
+    result.should.not.contain(false);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,10 +2621,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^19.13.6:
-  version "19.13.6"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.6.tgz#0ff4c2d58910883a393c07e14b1ac8491043d625"
-  integrity sha512-LRZU0pQg39e1wZ6YH8iDoVJp8uyHRW4VqO/CMMgv82hgaRdRTZCTeW8hoebNWf7WLQosqwPqMqk4ejc+N5FmSA==
+hof@^19.13.11:
+  version "19.13.11"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.11.tgz#f116baaccc33067533425a3e216124ed18873eb7"
+  integrity sha512-YQGRU2433cBMzp5Ke++6jqgEROXfwH9d86R+BE17MFB/BNlYlrTrLZrK8HJ6dC6dM76ThlByyLg3mgRLshxntQ==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -3642,9 +3642,9 @@ minimatch@3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixwith@^0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,9 +3746,9 @@ ms-countries@^1.0.0:
   integrity sha512-t+wlqwKFJl0yUNtwLbUWBd0irrsBBrTbHAK22dDN9Ut9H0zOf6iVKNz0DAINDtE2rgf+8hmzGt7SSmXAN7Im/A==
 
 ms-email-domains@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/ms-email-domains/-/ms-email-domains-2.5.0.tgz#47c0ec7570bcbb6bea6f63b314115f18a9b8cec6"
-  integrity sha512-TXB3H5+nZh0HZdICCNIrPZSFaWW6ZpSXxnSq6+bIN7/khj9xM+uNvBytHnNV/haBjwnz5uZeFron4Roby4FXiA==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/ms-email-domains/-/ms-email-domains-2.6.0.tgz#1dcb7e714699ccab18f535c4b9046aa5700746dc"
+  integrity sha512-CA8uVJJ5o5kcqwVy5cTR+29zpf1qiPrCUXVcZCd9ORe17H3EnZMVPIckaQK//hOd7IfXyP/hrT2kV4pMyjOIFQ==
 
 ms-nationalities@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What?
- Update ms-email-domains package to allow capital letters
- add unit test for capital letters in email domains 
- update hof package  
## Why?
Users are not able to access the form when they enter capital letters in the domain of their email address.
## How?
Amend ms-email-domains package to allow capital letters in domain
## Testing?
Tested locally
## Screenshots (optional)
## Anything Else? (optional)
