### PR TITLE
Nrm 139 fix expiry date

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ You can then start the server in the api development mode.
 ```bash
 $ yarn dev:api
 ```
+
 ## Acceptance tests  <a name="acceptance-tests"></a>
 
 [Google Puppeteer](https://developers.google.com/web/tools/puppeteer/) is our automated browser testing. It is a Node library which provides a high-level API to control headless Chrome or Chromium over the DevTools Protocol. It can also be configured to use full (non-headless) Chrome or Chromium.

--- a/apps/nrm/behaviours/resume-form-session.js
+++ b/apps/nrm/behaviours/resume-form-session.js
@@ -52,7 +52,7 @@ module.exports = superclass => class extends superclass {
 
         resBody.forEach(report => {
           const created = moment(report.created_at);
-          const expires = moment(report.created_at).add(config.reports.deletionTimeout, 'days');
+          const expires = moment(report.updated_at).add(config.reports.deletionTimeout, 'days').endOf('day');
           const remaining = expires.diff(moment(), 'days');
 
           const rep = {

--- a/apps/nrm/behaviours/save-and-exit.js
+++ b/apps/nrm/behaviours/save-and-exit.js
@@ -2,8 +2,8 @@
 const moment = require('moment');
 const config = require('../../../config');
 
-const calculateExpiryDate = updatedAtDate => {
-  return moment(updatedAtDate).add(config.reports.deletionTimeout, 'days')
+const calculateExpiryDate = () => {
+  return moment().add(config.reports.deletionTimeout, 'days')
     .format('DD MMMM YYYY');
 };
 
@@ -11,7 +11,7 @@ module.exports = superclass => class extends superclass {
   locals(req, res) {
     const superlocals = super.locals(req, res);
     const data = Object.assign({}, {
-      reportExpiration: calculateExpiryDate(req.sessionModel.get('updated_at')),
+      reportExpiration: calculateExpiryDate(),
       userEmail: req.sessionModel.get('user-email')
     });
     const locals = Object.assign({}, superlocals, data);

--- a/apps/nrm/behaviours/save-and-exit.js
+++ b/apps/nrm/behaviours/save-and-exit.js
@@ -2,8 +2,8 @@
 const moment = require('moment');
 const config = require('../../../config');
 
-const calculateExpiryDate = createdAtDate => {
-  return moment(createdAtDate).add(config.reports.deletionTimeout, 'days')
+const calculateExpiryDate = updatedAtDate => {
+  return moment(updatedAtDate).add(config.reports.deletionTimeout, 'days')
     .format('DD MMMM YYYY');
 };
 
@@ -11,7 +11,7 @@ module.exports = superclass => class extends superclass {
   locals(req, res) {
     const superlocals = super.locals(req, res);
     const data = Object.assign({}, {
-      reportExpiration: calculateExpiryDate(req.sessionModel.get('created_at')),
+      reportExpiration: calculateExpiryDate(req.sessionModel.get('updated_at')),
       userEmail: req.sessionModel.get('user-email')
     });
     const locals = Object.assign({}, superlocals, data);

--- a/apps/nrm/behaviours/save-form-session.js
+++ b/apps/nrm/behaviours/save-form-session.js
@@ -26,6 +26,11 @@ module.exports = superclass => class extends superclass {
         session.alertUser = true;
       }
 
+      // remove the firstAlert property added when the user has a week to complete the report
+      if (session.hasOwnProperty('firstAlert')) {
+        delete session.firstAlert;
+      }
+
       // skip requesting data service api when running in local mode
       if (config.env === 'local') {
         return next();

--- a/apps/nrm/views/reports.html
+++ b/apps/nrm/views/reports.html
@@ -38,7 +38,7 @@
       </table>
       <h2>Create a new report</h2>
       <p>Create your report to notify the Home Office of modern slavery and refer potential victims for support.</p>
-      <p>You can save your work for {{deletionTimeout}} calendar days, after which it will be deleted.</p>
+      <p>You have {{deletionTimeout}} calendar days to update or submit your report, after which it will be deleted.</p>
       <p>If you don't do anything for 1 hour, you will be logged out for security.</p>
       {{#input-submit}}create-report{{/input-submit}}
     </div>

--- a/apps/nrm/views/save-and-exit.html
+++ b/apps/nrm/views/save-and-exit.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
-    <p>You have until {{reportExpiration}} to submit your report.</p>
+    <p>You have until the {{reportExpiration}} to update or submit your report.</p>
     <p>We have sent a confirmation email to: {{userEmail}}</p>
     <p>You can return to your report at any time via the report modern slavery <a href="/start">start page on GOV.UK.</a></p>
   {{/page-content}}

--- a/kube/save-return-data-alerts/deployment.yml
+++ b/kube/save-return-data-alerts/deployment.yml
@@ -37,8 +37,8 @@ spec:
     spec:
       containers:
         - name: alert-service
-          # release v2.0.0
-          image: quay.io/ukhomeofficedigital/save-return-email-alerts:da399c8ae391bc8cac52f4b84450fd99b90397ad
+          # WIP
+          image: quay.io/ukhomeofficedigital/save-return-email-alerts:ca8d0849a3bdc1bbbf4b61610f397865a2023f84
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/save-return-data-alerts/deployment.yml
+++ b/kube/save-return-data-alerts/deployment.yml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: alert-service
-          # WIP
+          # v2.1.0 Fix expiration date
           image: quay.io/ukhomeofficedigital/save-return-email-alerts:ca8d0849a3bdc1bbbf4b61610f397865a2023f84
           imagePullPolicy: Always
           envFrom:

--- a/test/_unit/nrm/behaviours/save-and-exit.spec.js
+++ b/test/_unit/nrm/behaviours/save-and-exit.spec.js
@@ -1,15 +1,14 @@
 'use strict';
 
+const moment = require('moment');
 const reqres = require('reqres');
 const Behaviour = require('../../../../apps/nrm/behaviours/save-and-exit');
-const TestDate = 'Mon 05 Jul 2021 13:28:56 +0100';
-const UpdatedTestDate = 'Mon 05 Jul 2021 14:10:26 +0100';
-const TestDateFeb = 'Sat 29 Feb 2020 13:28:56 +0100';
-const UpdatedTestDateFeb = 'Sat 29 Feb 2020 14:18:52 +0100';
-const CorrectDate = '02 August 2021';
-const CorrectDateFeb = '28 March 2020';
+
 const Route = 'save-and-exit';
 const UserEmail = 'mary-jane-parker@homeoffice.gov.uk';
+const DeletionTimeout = 28;
+const ExpectedExpiryDate = moment(new Date()).add(DeletionTimeout, 'days')
+  .format('DD MMMM YYYY');
 
 describe('/apps/nrm/behaviours/save-and-exit', () => {
   it('exports a function', () => {
@@ -27,14 +26,11 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
   let SaveAndExit;
 
   const superLocals = {
-    route: Route,
-    created_at: TestDate,
-    updated_at: UpdatedTestDate,
-    'user-email': UserEmail
+    route: Route
   };
 
   const data = Object.assign({}, {
-    reportExpiration: CorrectDate,
+    reportExpiration: ExpectedExpiryDate,
     userEmail: UserEmail
   });
 
@@ -54,10 +50,7 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
     });
     afterEach(() => {
       locals = {
-        route: Route,
-        created_at: TestDate,
-        updated_at: UpdatedTestDate,
-        'user-email': UserEmail
+        route: Route
       };
 
       Base.prototype.locals.restore();
@@ -66,72 +59,25 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
     it('returns an extended locals with expiry date calculated', async () => {
       const expected = {
         route: Route,
-        created_at: TestDate,
-        updated_at: UpdatedTestDate,
-        'user-email': UserEmail,
-        reportExpiration: CorrectDate,
+        reportExpiration: ExpectedExpiryDate,
         userEmail: UserEmail
       };
 
-      req.sessionModel.get.withArgs('updated_at').returns(UpdatedTestDate);
       req.sessionModel.get.withArgs('user-email').returns(UserEmail);
 
       const result = instance.locals(req, res);
       result.should.deep.equal(expected);
       expect(sessionModel.reset).to.have.been.called;
     });
-
-    it('returns an extended locals with expiry date calculated for 29th Feb', async () => {
-      const expected = {
-        route: Route,
-        created_at: TestDateFeb,
-        updated_at: UpdatedTestDateFeb,
-        'user-email': UserEmail,
-        reportExpiration: CorrectDateFeb,
-        userEmail: UserEmail
-      };
-      // eslint-disable-next-line camelcase
-      locals.created_at = TestDateFeb;
-      locals.updated_at = UpdatedTestDateFeb;
-
-      req.sessionModel.get.withArgs('updated_at').returns(UpdatedTestDateFeb);
-      req.sessionModel.get.withArgs('user-email').returns(UserEmail);
-
-      const result = instance.locals(req, res);
-      result.should.deep.equal(expected);
-      expect(sessionModel.reset).to.have.been.called;
-    });
-
-    it('returns an Invalid date when given an empty updated date', async () => {
-      const expected = {
-        route: Route,
-        created_at: TestDate,
-        updated_at: '',
-        'user-email': UserEmail,
-        reportExpiration: 'Invalid date',
-        userEmail: UserEmail
-      };
-      // eslint-disable-next-line camelcase
-      locals.updated_at = '';
-
-      req.sessionModel.get.withArgs('updated_at').returns('');
-      req.sessionModel.get.withArgs('user-email').returns(UserEmail);
-
-      const result = instance.locals(req, res);
-      result.should.deep.equal(expected);
-      expect(sessionModel.reset).to.have.been.called;
-    });
-
 
     it('resets the session', () => {
       instance.locals(req, res);
       expect(sessionModel.reset).to.have.been.called;
     });
 
-    it('gets the users email and report updated date from the previous page', () => {
+    it('gets the users email from the previous page', () => {
       instance.locals(req, res);
       expect(sessionModel.get).to.have.been.calledWith('user-email');
-      expect(sessionModel.get).to.have.been.calledWith('updated_at');
     });
   });
 });

--- a/test/_unit/nrm/behaviours/save-and-exit.spec.js
+++ b/test/_unit/nrm/behaviours/save-and-exit.spec.js
@@ -3,7 +3,9 @@
 const reqres = require('reqres');
 const Behaviour = require('../../../../apps/nrm/behaviours/save-and-exit');
 const TestDate = 'Mon 05 Jul 2021 13:28:56 +0100';
+const UpdatedTestDate = 'Mon 05 Jul 2021 14:10:26 +0100';
 const TestDateFeb = 'Sat 29 Feb 2020 13:28:56 +0100';
+const UpdatedTestDateFeb = 'Sat 29 Feb 2020 14:18:52 +0100';
 const CorrectDate = '02 August 2021';
 const CorrectDateFeb = '28 March 2020';
 const Route = 'save-and-exit';
@@ -27,6 +29,7 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
   const superLocals = {
     route: Route,
     created_at: TestDate,
+    updated_at: UpdatedTestDate,
     'user-email': UserEmail
   };
 
@@ -53,6 +56,7 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
       locals = {
         route: Route,
         created_at: TestDate,
+        updated_at: UpdatedTestDate,
         'user-email': UserEmail
       };
 
@@ -63,12 +67,13 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
       const expected = {
         route: Route,
         created_at: TestDate,
+        updated_at: UpdatedTestDate,
         'user-email': UserEmail,
         reportExpiration: CorrectDate,
         userEmail: UserEmail
       };
 
-      req.sessionModel.get.withArgs('created_at').returns(TestDate);
+      req.sessionModel.get.withArgs('updated_at').returns(UpdatedTestDate);
       req.sessionModel.get.withArgs('user-email').returns(UserEmail);
 
       const result = instance.locals(req, res);
@@ -80,14 +85,16 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
       const expected = {
         route: Route,
         created_at: TestDateFeb,
+        updated_at: UpdatedTestDateFeb,
         'user-email': UserEmail,
         reportExpiration: CorrectDateFeb,
         userEmail: UserEmail
       };
       // eslint-disable-next-line camelcase
       locals.created_at = TestDateFeb;
+      locals.updated_at = UpdatedTestDateFeb;
 
-      req.sessionModel.get.withArgs('created_at').returns(TestDateFeb);
+      req.sessionModel.get.withArgs('updated_at').returns(UpdatedTestDateFeb);
       req.sessionModel.get.withArgs('user-email').returns(UserEmail);
 
       const result = instance.locals(req, res);
@@ -95,18 +102,19 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
       expect(sessionModel.reset).to.have.been.called;
     });
 
-    it('returns an Invalid date when given an empty created_at date', async () => {
+    it('returns an Invalid date when given an empty updated date', async () => {
       const expected = {
         route: Route,
-        created_at: '',
+        created_at: TestDate,
+        updated_at: '',
         'user-email': UserEmail,
         reportExpiration: 'Invalid date',
         userEmail: UserEmail
       };
       // eslint-disable-next-line camelcase
-      locals.created_at = '';
+      locals.updated_at = '';
 
-      req.sessionModel.get.withArgs('created_at').returns('');
+      req.sessionModel.get.withArgs('updated_at').returns('');
       req.sessionModel.get.withArgs('user-email').returns(UserEmail);
 
       const result = instance.locals(req, res);
@@ -120,10 +128,10 @@ describe('/apps/nrm/behaviours/save-and-exit', () => {
       expect(sessionModel.reset).to.have.been.called;
     });
 
-    it('gets the users email and report creation date from the previous page', () => {
+    it('gets the users email and report updated date from the previous page', () => {
       instance.locals(req, res);
       expect(sessionModel.get).to.have.been.calledWith('user-email');
-      expect(sessionModel.get).to.have.been.calledWith('created_at');
+      expect(sessionModel.get).to.have.been.calledWith('updated_at');
     });
   });
 });


### PR DESCRIPTION
## What?
- Fix the expiry date to be based on when the form was last updated. 

After Shamil approved the changes and Satya tested on the branch.
- On the save and exit page - removed the date argument as the previous one was not passing through a timestamp and the time 'now' is being used which works, as this is when the form was last updated
- Fixed unit test related to changes to the above
- Updated the image of the save and email alerts service

## Why?
- Currently the expiry date is based on the date the report was created not the date it was last updated, which is what it should be.
## How?
- Change the expiry date displayed on the dashboard, and save-and-exit page. Also, altered text on these pages to clarify the changes. 
- Remove the firstAlert property from the report if the form is updated after a 7 day alert has already been sent, so when the deadline changes after they update it, they will receive another 7 day alert. 
## Testing?
Unit tests passing.
Tested locally with the modified save-return-email-alerts, and the save-return-api running. Mocked some data in the database.
- Dashboard - shows form created on the same day has 28 days remaining. Expiry date on dashboard, Notify email (Save template) and save and exit page all show the correct date when saved initially and when updated.
- Forms created on 2 different days but within 24 hours of testing, correctly show different days remaining (NRM-76)
- Notify sends emails for inactivity, 7 day alert (when there is 7 days remaining), deletion (form deleted after 28 days have passed since the last update date) and save template. 
## Screenshots (optional)
## Anything Else? (optional)
