### PR TITLE
NRM-167: Additional Logging to the Service

### DIFF
--- a/apps/nrm/behaviours/check-email-token.js
+++ b/apps/nrm/behaviours/check-email-token.js
@@ -21,7 +21,7 @@ module.exports = superclass => class extends superclass {
     return checkToken.read(token)
       .then(user => {
         if (user.valid) {
-        // delete the token once it's been used
+          // delete the token once it's been used
           checkToken.delete(token);
           // this is so a user can go back without requesting a new token
           req.sessionModel.set('valid-token', true);
@@ -31,7 +31,7 @@ module.exports = superclass => class extends superclass {
         }
         return res.redirect('/nrm/token-invalid');
       })
-    // eslint-disable-next-line no-console
-      .catch(err => console.log(err));
+      .catch(err => req.log('info', `Check Token Error: ${err}`)
+      );
   }
 };

--- a/apps/nrm/behaviours/reset-journey-to-submit-nrm.js
+++ b/apps/nrm/behaviours/reset-journey-to-submit-nrm.js
@@ -7,6 +7,9 @@ module.exports = superclass => class extends superclass {
     const stepsBeforeReferralQuestion = formSteps.slice(0, formSteps.indexOf('/pv-want-to-submit-nrm') + 1);
     const filteredSteps = currentSteps.filter(step => stepsBeforeReferralQuestion.includes(step));
 
+    const externalID = req.sessionModel.get('externalID');
+    req.log('info', `External ID: ${externalID}, Journey Reset`);
+
     req.sessionModel.set('steps', filteredSteps);
 
     return super.saveValues(req, res, next);

--- a/apps/nrm/behaviours/save-form-session.js
+++ b/apps/nrm/behaviours/save-form-session.js
@@ -36,6 +36,9 @@ module.exports = superclass => class extends superclass {
         return next();
       }
 
+      const externalID = req.sessionModel.get('externalID');
+      req.log('info', `External ID: ${externalID}, Saving Form Session: ${req.sessionModel.get('id')}`);
+
       request.post({
         headers: {'content-type': 'application/json'},
         url: config.saveService.host + ':' + config.saveService.port + '/reports',
@@ -46,6 +49,7 @@ module.exports = superclass => class extends superclass {
         })
       }, (error, response, body) => {
         if (error) {
+          req.log('info', `External ID: ${externalID}, Error Saving Session: ${error}`);
           next(error);
         }
         const resBody = JSON.parse(body);

--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -1,9 +1,9 @@
 'use strict';
 
 /* eslint complexity: 0 max-statements: 0 */
+/* eslint-disable dot-notation */
 
 const _ = require('lodash');
-const uuid = require('uuid/v4');
 
 module.exports = data => {
   const response = {};
@@ -186,7 +186,7 @@ module.exports = data => {
 
   response.SupportProviderContactByPhone = data['pv-phone-number-yes'];
   // icw resolver will look for any existing case before submitting a report to prevent duplicates
-  response.ExternalId = uuid();
+  response.ExternalId = data['externalID'];
 
   return response;
 };


### PR DESCRIPTION
**Changes**	

- Generated External ID at the beginning of the service and added to the session model for logging through the service.
- Adding logs to saving form session, casework submissions, resume and save form sessions.

**Reason**

- Increased logging was required in NRM to check cases were being submitted to the queue, and to log any errors.
- External ID was added to the beginning of the service, so the whole user journey could be tracked through the service and into iCasework via filtering the External ID within openSearch.

**Tests**

- Tested multiple reports through the service and into iCasework where the External ID can be observed. (Screengrab's on Jira Ticket NRM-168: https://collaboration.homeoffice.gov.uk/jira/browse/NRM-167)
