### PR TITLE
NRM-167: Ensuring a UUID is sent to iCasework

### DIFF
--- a/apps/nrm/behaviours/casework-submission.js
+++ b/apps/nrm/behaviours/casework-submission.js
@@ -23,8 +23,6 @@ module.exports = conf => {
 
   return superclass => class extends superclass {
     saveValues(req, res, next) {
-      const externalID = req.sessionModel.get('externalID');
-
       super.saveValues(req, res, err => {
         if (err) {
           return next(err);
@@ -32,6 +30,10 @@ module.exports = conf => {
 
         const caseWorkPayload = appConfig.writeToCasework ? config.prepare(req.sessionModel.toJSON()) :
           { info: 'No submission was made to icasework' };
+
+        const externalID = req.sessionModel.get('externalID')  || caseWorkPayload.ExternalId;
+
+        const reportReference = req.sessionModel.get('reference');
 
         req.sessionModel.set('jsonPayload', caseWorkPayload);
 
@@ -42,7 +44,8 @@ module.exports = conf => {
           // send casework model to AWS SQS
           const caseworkModel = config.prepare(req.sessionModel.toJSON());
           const caseworkID = uuid();
-          req.log('info', `External ID: ${externalID}, Submitting Case to Queue ${caseworkID}`);
+          req.log('info', `External ID: ${externalID}, Report Reference: ${reportReference},
+            Submitting Case to Queue Case ID: ${caseworkID}`);
           producer.send([{
             id: caseworkID,
             body: JSON.stringify(caseworkModel)

--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -4,6 +4,7 @@
 /* eslint-disable dot-notation */
 
 const _ = require('lodash');
+const uuid = require('uuid/v4');
 
 module.exports = data => {
   const response = {};
@@ -186,7 +187,7 @@ module.exports = data => {
 
   response.SupportProviderContactByPhone = data['pv-phone-number-yes'];
   // icw resolver will look for any existing case before submitting a report to prevent duplicates
-  response.ExternalId = data['externalID'];
+  response.ExternalId = data['externalID'] ? data['externalID'] : uuid();
 
   return response;
 };


### PR DESCRIPTION
**Changes**

- Added a case if the externalID is undefined, a UUID is generated on the submission.js page.
- Changed the casework-submission page to log the case reference with the external ID.

**Reason**

- This is a final check in the data generated for iCasework, that an external ID is present and if not generate one and log submission with this ID. 


