### PR TITLE
pipeline check

### DIFF
--- a/browsers/chrome/Dockerfile
+++ b/browsers/chrome/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main' >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get update --allow-unauthenticated && \
-  apt-get install -y google-chrome-unstable --no-install-recommends --allow-unauthenticated && \
+  apt-get upgrade -y --allow-unauthenticated && \
+  apt-get install -y google-chrome-stable --no-install-recommends --allow-unauthenticated && \
   rm -fr /var/lib/apt/lists/* && \
   # Uninstall Curl, it's configuration files and the installation file from Ubuntu
   apt-get purge --auto-remove -y curl && \


### PR DESCRIPTION
## Changes

- Dockerfile for chrome browser updated to change google chrome to stable version to mitigate a dependency error 'libu2f-udev' being triggered on the pipeline and acceptance tests not running.

## Reason

- Acceptance tests not running on pipeline and triggering errors.

## Testing

- Tested on branch environment and all acceptance tests ran and passed successfully.
