### PR TITLE
NRM-224: Re-instating what happened page and iCasework mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,10 @@ There are a bunch of microservices as part of modernslavery:
 
 ## Release Guidelines <a name="release-guidelines"></a>
 <a href="https://github.com/UKHomeOffice/modern-slavery/tree/master/documents/release-guidelines.md">More Details</a>
+
+## Legacy Fields and Pages 
+
+'what-happened' page has been removed from the main journey through the form as it no longer required. Its present only 
+for legacy information saved as part of the 'save and return' process, so users can update if required before submission. 
+This page should be reviewed within 12 months to see if any active cases in the 'save and return' feature are using this
+field before the page can be permanently removed. 

--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -88,6 +88,20 @@ module.exports = {
       'not-sure'
     ]
   },
+  'what-happened': {
+    backLink: false,
+    mixin: 'textarea',
+    validate: ['required', {type: 'maxlength', arguments: [15000]}],
+    legend: {
+      className: 'govuk-textarea no-margin'
+    },
+    attributes: [
+      {
+        attribute: 'rows',
+        value: 14
+      }
+    ]
+  },
   birthplace: {
     mixin: 'input-text',
     validate: ['required', {type: 'maxlength', arguments: [15000]}]

--- a/apps/nrm/index.js
+++ b/apps/nrm/index.js
@@ -107,7 +107,16 @@ module.exports = {
       fields: ['pv-under-age-at-time-of-exploitation'],
       next: '/what-is-their-background'
     },
+    '/what-happened': {
+      backLink: 'pv-under-age-at-time-of-exploitation',
+      behaviours: [
+        saveFormSession
+      ],
+      fields: ['what-happened'],
+      next: '/what-is-their-background'
+    },
     '/what-is-their-background': {
+      backLink: 'pv-under-age-at-time-of-exploitation',
       behaviours: [
         saveFormSession
       ],


### PR DESCRIPTION
## Changes?

- Re-added 'what-happened' to the index.js step
- Re-added ' what-happened' field information into 'fields/index.js'
- Updated Readme

## Reason

- To mitigate the scenario whereby data would be saved in the 'what-happened' field in the save and return feature, and this data would be un-editable and lost if this legacy page was in-accessible.

