### PR TITLE
NRM-231: Added bradfordcft to email domains list

### DIFF
--- a/ms-lists/ms_email_domain_list.json
+++ b/ms-lists/ms_email_domain_list.json
@@ -48,5 +48,6 @@
     "worcschildrenfirst.org.uk",
     "bsigroup.com",
     "bsicsiruk.cjsm.net",
-    "refugeecouncil.org.uk"
+    "refugeecouncil.org.uk",
+    "bradfordcft.org.uk"
 ]


### PR DESCRIPTION
**Changes**

- bradfordcft.org.uk added to ms_email_domain_list.json

**Reason**

As requested by business: Bradford Children’s Services is now referred to as Bradford Children and Families Trust. As such, the new email domain needs to be whitelisted.

