### PR TITLE
Upgrade HOF to v20.3.0 for Redis upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "accessible-autocomplete": "^2.0.2",
     "govuk-frontend": "^2.7.0",
-    "hof": "^19.14.17",
+    "hof": "^20.3.11",
     "ioredis": "^4.0.0",
     "jquery": "^3.3.1",
     "knex": "^0.95.11",


### PR DESCRIPTION
## What?

update HOF package from v20.2.11 to v20.3.11 with tag _upgrade-redis-beta_

## Why?

Required to test newer version of Redis in NRM form: https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-308
https://collaboration.homeoffice.gov.uk/jira/browse/NRM-240

## How?

update version of hof in package.json

## Testing?

To be carried out by QAT team