### PR TITLE
HOFF-625: Install postgres for pre-upgrade checks for database in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2 && \
+    apk add postgresql
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \


### PR DESCRIPTION
## What?
-  Added postgres to Dockerfile to install postgres in order to carry out checks as part of Postgres version upgrade  - [HOFF-625](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-625)
## Why?
- Before we request ACP to upgrade the postgres database instance from v11.22 to v14.10 for Modern Slavery in the Production Environment we need to connect to the DB to get insights on data. This helps us to verify the integrity of the data in the upgraded DB as part of Data Validation.
## How?
-  Added postgres to Dockerfile
## Testing?
- Tested in notprod environment
## Screenshots (optional)
## Anything Else? (optional)
