### PR TITLE
Feature/NRM-265 removed `co-operate-with-police-referral` page

### DIFF
--- a/acceptance-test/user-pathways/happy-path/happy-path.test.js
+++ b/acceptance-test/user-pathways/happy-path/happy-path.test.js
@@ -298,8 +298,6 @@ describe.only('User path(s)', () => {
       await clickSelector(page, CONTINUE_BUTTON);
       await clickSelector(page, PV_PHONE_NUMBER_NO_OPTION);
       await clickSelector(page, CONTINUE_BUTTON);
-      await clickSelector(page, POLICE_CONTACT_YES_OPTION);
-      await clickSelector(page, CONTINUE_BUTTON);
     }
 
     await focusThenType(page, FR_DETAILS_FIRST_NAME_INPUT, 'Jack');
@@ -312,7 +310,7 @@ describe.only('User path(s)', () => {
   }
 
   const timeoutInMins = num => num * 60000;
-  const defaultTimeout = timeoutInMins(5);
+  const defaultTimeout = timeoutInMins(20);
 
   it('Happy path - Adult', async () => {
     try {

--- a/apps/nrm/index.js
+++ b/apps/nrm/index.js
@@ -544,7 +544,7 @@ module.exports = {
       ],
       next: '/pv-phone-number',
       forks: [{
-        target: '/co-operate-with-police-referral',
+        target: '/fr-details',
         condition: req => req.sessionModel.get('does-pv-need-support') === 'no'
       }]
     },
@@ -565,7 +565,7 @@ module.exports = {
       ],
       next: '/pv-phone-number',
       forks: [{
-        target: '/co-operate-with-police-referral',
+        target: '/fr-details',
         condition: req => req.sessionModel.get('does-pv-need-support') === 'no'
       }]
     },
@@ -576,14 +576,6 @@ module.exports = {
       fields: [
         'pv-phone-number',
         'pv-phone-number-yes'
-      ],
-      next: '/co-operate-with-police-referral'
-    },
-    '/co-operate-with-police-referral': {
-      template: 'co-operate-with-police',
-      fields: ['co-operate-with-police'],
-      behaviours: [
-        saveFormSession
       ],
       next: '/fr-details'
     },

--- a/test/_ui-integration/nrm/application.spec.js
+++ b/test/_ui-integration/nrm/application.spec.js
@@ -547,17 +547,17 @@ describe('the journey of a nrm application', () => {
       expect(response.text).to.contain('Found. Redirecting to /nrm/pv-phone-number');
     });
 
-    it('goes to the co-operate-with-police-referral page when user selects no phone number', async () => {
+    it('goes to the fr-details page when user selects no phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-phone-number': 'no'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
+      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
     });
 
-    it('goes to the co-operate-with-police-referral page when user enters pv phone number', async () => {
+    it('goes to the fr-details page when user enters pv phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
@@ -565,7 +565,7 @@ describe('the journey of a nrm application', () => {
         'pv-phone-number-yes': '01234567890'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
+      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
     });
 
     it('goes to the someone-else page when user enters who-contact', async () => {
@@ -599,42 +599,22 @@ describe('the journey of a nrm application', () => {
       expect(response.text).to.contain('Found. Redirecting to /nrm/pv-phone-number');
     });
 
-    it('goes to the co-operate-with-police-referral page when user selects no phone number', async () => {
+    it('goes to the fr-details page when user selects no phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-phone-number': 'no'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
+      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
     });
 
-    it('goes to the co-operate-with-police-referral page when user enters pv phone number', async () => {
+    it('goes to the fr-details page when user enters pv phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-phone-number': 'yes',
         'pv-phone-number-yes': '01234567890'
-      });
-
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
-    });
-
-    it('goes to the fr-details page when user selects yes cooperate-with-police-referral', async () => {
-      const URI = '/co-operate-with-police-referral';
-      await initSession(URI);
-      const response = await passStep(URI, {
-        'co-operate-with-police': 'yes'
-      });
-
-      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
-    });
-
-    it('goes to the fr-details page when user selects not to cooperate-with-police-referral', async () => {
-      const URI = '/co-operate-with-police-referral';
-      await initSession(URI);
-      const response = await passStep(URI, {
-        'co-operate-with-police': 'no'
       });
 
       expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');

--- a/test/_ui-integration/nrm/validations.spec.js
+++ b/test/_ui-integration/nrm/validations.spec.js
@@ -1001,22 +1001,6 @@ describe('validation checks of the nrm journey', () => {
     });
   });
 
-  describe('Cooperate with Police Referral Validation', () => {
-    it('does not pass the cooperate with police referral page if nothing is selected', async () => {
-      const URI = '/co-operate-with-police-referral';
-      await initSession(URI);
-      await passStep(URI, {});
-
-      const res = await getUrl(URI);
-      const docu = await parseHtml(res);
-      const validationSummary = docu.find('.validation-summary');
-
-      expect(validationSummary.length === 1).to.be.true;
-      expect(validationSummary.html())
-        .to.match(/You must select an option/);
-    });
-  });
-
   describe('First Responder Contact Details Validations', () => {
     it('does not pass the fr details page if nothing is entered', async () => {
       const URI = '/fr-details';


### PR DESCRIPTION
## What?
Removed page can police contact them about their case? 
## Why?
as per stakeholder ticket [NRM-265](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-265)
## How?
Update `index.js` but not `pages.json` or `fields.js` since the field `co-operate-with police` is currently used in `co-operate-with-police-dtn` page.
## Testing?
removed the tests concerning `/nrm/co-operate-with-police-referral` page
## Screenshots (optional)
## Anything Else? (optional)
