### PR TITLE
NRM-265-and-279-remove-can-the-police-contact-them

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,50 +3,50 @@ version: v1.22.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-AXIOS-6032459:
-    - '*':
-        reason: will be resolved with HOFF-659 
+    - "*":
+        reason: will be resolved with HOFF-659
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
-
+  
   SNYK-JS-AXIOS-6124857:
-    - '*':
-        reason: will be resolved with HOFF-659 
+    - "*":
+        reason: will be resolved with HOFF-659
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
 
   SNYK-JS-AXIOS-6144788:
-    - '*':
-        reason: will be resolved with HOFF-659 
+    - "*":
+        reason: will be resolved with HOFF-659
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
 
   SNYK-JS-MARKDOWNIT-6483324:
-    - '*':
+    - "*":
         reason: No upgrade or patch available yet
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
-      
+
   SNYK-JS-INFLIGHT-6095116:
-    - '*':
+    - "*":
         reason: No upgrade or patch available yet
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
 
   SNYK-JS-REQUEST-3361831:
-    - '*':
+    - "*":
         reason: No upgrade or patch available yet
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
 
   SNYK-JS-TOUGHCOOKIE-5672873:
-    - '*':
-        reason: will be resolved with HOFF-659 
+    - "*":
+        reason: will be resolved with HOFF-659
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
+ 
   SNYK-JS-BRACES-6838727:
-    - '*':
+    - "*":
         reason: No upgrade or patch available
         expires: 2024-07-16T00:00:00.000Z
         created: 2024-04-16T11:0522.224Z
-
 patch: {}

--- a/acceptance-test/test-config.js
+++ b/acceptance-test/test-config.js
@@ -54,7 +54,6 @@ module.exports = {
     PV_CONTACT_DETAILS_EMAIL_INPUT: '#pv-contact-details-email-input',
     PV_CONTACT_DETAILS_EMAIL_SAFE_OPTION: '#pv-contact-details-email-check',
     PV_PHONE_NUMBER_NO_OPTION: '#pv-phone-number-no',
-    POLICE_CONTACT_YES_OPTION: '#co-operate-with-police-yes',
     FR_DETAILS_NAME_INPUT: '#fr-details-name',
     FR_DETAILS_ROLE_INPUT: '#fr-details-role',
     FR_DETAILS_PHONE_INPUT: '#fr-details-phone',

--- a/acceptance-test/user-pathways/happy-path/happy-path.test.js
+++ b/acceptance-test/user-pathways/happy-path/happy-path.test.js
@@ -59,7 +59,6 @@ const {
   PV_CONTACT_DETAILS_EMAIL_INPUT,
   PV_CONTACT_DETAILS_EMAIL_SAFE_OPTION,
   PV_PHONE_NUMBER_NO_OPTION,
-  POLICE_CONTACT_YES_OPTION,
   FR_DETAILS_FIRST_NAME_INPUT,
   FR_DETAILS_LAST_NAME_INPUT,
   FR_DETAILS_ROLE_INPUT,
@@ -140,15 +139,15 @@ describe.only('User path(s)', () => {
     await clickSelector(page, CONTINUE_BUTTON);
     await focusThenType(page, PV_NATIONALITY, 'French');
     await clickSelector(page, CONTINUE_BUTTON);
-    await clickSelector(page, POLICE_CONTACT_YES_OPTION);
-    await clickSelector(page, CONTINUE_BUTTON);
-    await focusThenType(page, PV_NAME_FIRST_NAME, 'Robert');
-    await focusThenType(page, PV_NAME_LAST_NAME, 'Maxwell');
-    await clickSelector(page, CONTINUE_BUTTON);
-    await clickSelector(page, PV_CONTACT_DETAILS_EMAIL_OPTION);
-    await focusThenType(page, PV_CONTACT_DETAILS_EMAIL_INPUT, 'robert.maxwell@pvrefuse.com');
-    await clickSelector(page, PV_CONTACT_DETAILS_EMAIL_SAFE_OPTION);
-    await clickSelector(page, CONTINUE_BUTTON);
+    /**  once merged with  Cooperation with Authorities add test back in
+    // await focusThenType(page, PV_NAME_FIRST_NAME, 'Robert');
+    // await focusThenType(page, PV_NAME_LAST_NAME, 'Maxwell');
+    // await clickSelector(page, CONTINUE_BUTTON);
+    // await clickSelector(page, PV_CONTACT_DETAILS_EMAIL_OPTION);
+    // await focusThenType(page, PV_CONTACT_DETAILS_EMAIL_INPUT, 'robert.maxwell@pvrefuse.com');
+    // await clickSelector(page, PV_CONTACT_DETAILS_EMAIL_SAFE_OPTION);
+    // await clickSelector(page, CONTINUE_BUTTON);
+    */
   }
 
   /**
@@ -299,8 +298,6 @@ describe.only('User path(s)', () => {
       await clickSelector(page, PV_CONTACT_DETAILS_EMAIL_SAFE_OPTION);
       await clickSelector(page, CONTINUE_BUTTON);
       await clickSelector(page, PV_PHONE_NUMBER_NO_OPTION);
-      await clickSelector(page, CONTINUE_BUTTON);
-      await clickSelector(page, POLICE_CONTACT_YES_OPTION);
       await clickSelector(page, CONTINUE_BUTTON);
     }
 

--- a/apps/nrm/behaviours/format-answers.js
+++ b/apps/nrm/behaviours/format-answers.js
@@ -32,12 +32,6 @@ const formatAnswers = req => {
     });
   }
 
-  if (req.sessionModel.get('co-operate-with-police')) {
-    data = Object.assign({}, data, {
-      formattedCoOperateWithPolice: capitaliseText(req.sessionModel.get('co-operate-with-police'))
-    });
-  }
-
   if (req.sessionModel.get('pv-gender')) {
     let formattedPvGenderValue = removeDashesFromText(capitaliseText(req.sessionModel.get('pv-gender')));
 

--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -1130,17 +1130,6 @@ module.exports = {
       field: 'pv-phone-number'
     }
   },
-  'co-operate-with-police': {
-    mixin: 'radio-group',
-    validate: ['required'],
-    legend: {
-      className: 'visuallyhidden'
-    },
-    options: [
-      'yes',
-      'no'
-    ]
-  },
   'fr-details-first-name': {
     mixin: 'input-text',
     validate: ['required', {type: 'maxlength', arguments: [15000]}]

--- a/apps/nrm/index.js
+++ b/apps/nrm/index.js
@@ -380,19 +380,14 @@ module.exports = {
         'pv-nationality',
         'pv-nationality-second'
       ],
-      next: '/co-operate-with-police-dtn'
-    },
-    '/co-operate-with-police-dtn': {
-      template: 'co-operate-with-police',
-      fields: ['co-operate-with-police'],
-      behaviours: [
-        saveFormSession
-      ],
-      next: '/confirm',
       forks: [{
         target: '/pv-name-dtn',
-        condition: req => req.sessionModel.get('co-operate-with-police') === 'yes'
-      }]
+        condition: {
+          field: 'authorities-cooperation',
+          value: 'yes'
+        }
+      }],
+      next: '/confirm'
     },
     '/pv-name-dtn': {
       template: 'pv-name',
@@ -544,7 +539,7 @@ module.exports = {
       ],
       next: '/pv-phone-number',
       forks: [{
-        target: '/co-operate-with-police-referral',
+        target: '/fr-details',
         condition: req => req.sessionModel.get('does-pv-need-support') === 'no'
       }]
     },
@@ -565,7 +560,7 @@ module.exports = {
       ],
       next: '/pv-phone-number',
       forks: [{
-        target: '/co-operate-with-police-referral',
+        target: '/fr-details',
         condition: req => req.sessionModel.get('does-pv-need-support') === 'no'
       }]
     },
@@ -576,14 +571,6 @@ module.exports = {
       fields: [
         'pv-phone-number',
         'pv-phone-number-yes'
-      ],
-      next: '/co-operate-with-police-referral'
-    },
-    '/co-operate-with-police-referral': {
-      template: 'co-operate-with-police',
-      fields: ['co-operate-with-police'],
-      behaviours: [
-        saveFormSession
       ],
       next: '/fr-details'
     },

--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -152,7 +152,6 @@ module.exports = data => {
   response.CountryLabel = _.upperFirst(data['fr-location']);
   response.HowToNotify = _.isArray(data['pv-contact-details']) ?
     'Email, Post' : _.upperFirst(data['pv-contact-details']);
-  response.CanPoliceContactPV = _.upperFirst(data['co-operate-with-police']);
   response.PoliceForceCRN = data['reported-to-police-crime-reference'];
   response.CIDReference = data['pv-ho-reference-type'];
 

--- a/apps/nrm/translations/src/en/fields.json
+++ b/apps/nrm/translations/src/en/fields.json
@@ -681,17 +681,6 @@
   "pv-phone-number-yes": {
     "label": "Enter potential victim's phone number"
   },
-  "co-operate-with-police": {
-    "legend": "Can the police contact them about their case?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
-  },
   "fr-details-first-name": {
     "label": "First name"
   },

--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -183,9 +183,6 @@
   "pv-phone-number": {
     "header": "Can the support provider contact them by phone?"
   },
-  "co-operate-with-police": {
-    "header": "Can the police contact them about their case?"
-  },
   "fr-details": {
     "header": "What are your contact details?",
     "read-only-field-1-label": "Email",

--- a/apps/nrm/translations/src/en/validation.json
+++ b/apps/nrm/translations/src/en/validation.json
@@ -293,9 +293,6 @@
     "required": "You must enter the potential victim's phone number",
     "maxlength": "You must enter no more than 15,000 characters"
   },
-  "co-operate-with-police" : {
-    "required": "You must select an option"
-  },
   "fr-details-first-name" : {
     "required": "You must enter your first name ",
     "maxlength": "You must enter no more than 15,000 characters"

--- a/apps/nrm/views/co-operate-with-police.html
+++ b/apps/nrm/views/co-operate-with-police.html
@@ -1,7 +1,0 @@
-{{<partials-page}}
-  {{$page-content}}
-    <p>{{#markdown}}co-operate-with-police{{/markdown}}</p>
-    {{#renderField}}co-operate-with-police{{/renderField}}
-    {{#input-submit}}continue{{/input-submit}} {{> partials-save-and-exit-link}}
-  {{/page-content}}
-{{/partials-page}}

--- a/apps/nrm/views/partials/summary-table-potential-victim.html
+++ b/apps/nrm/views/partials/summary-table-potential-victim.html
@@ -50,19 +50,7 @@
       </tr>
       {{/values.refuse-nrm}}
       {{/isDutyToNotifyPath}}
-
-      {{#values.co-operate-with-police}}
-        <tr>
-          <td>{{#t}}pages.confirm.fields.co-operate-with-police.label{{/t}}</td>
-          <td class="no-white-space">
-            <span>{{formattedCoOperateWithPolice}}</span>
-          </td>
-          <td>
-            <a href="/nrm/co-operate-with-police-{{#values.is-referral}}referral{{/values.is-referral}}{{^values.is-referral}}dtn{{/values.is-referral}}/edit" class="button" aria-label="Change {{#t}}pages.confirm.fields.refuse-nrm.label{{/t}}">Change</a>
-          </td>
-        </tr>
-      {{/values.co-operate-with-police}}
-
+      
       {{#values.pv-name-first-name}}
       <tr>
         <td>{{#t}}pages.confirm.fields.pv-name.label{{/t}}</td>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ms-uk-local-authorities": "^2.2.3",
     "ms-uk-police-forces": "^2.0.0",
     "ms-uk-regions": "^2.1.1",
-    "notifications-node-client": "8.0.0",
+    "notifications-node-client": "^8.0.0",
     "pg": "^8.7.1",
     "request": "^2.88.0",
     "sqs-producer": "^1.6.3",

--- a/test/_ui-integration/nrm/application.spec.js
+++ b/test/_ui-integration/nrm/application.spec.js
@@ -547,17 +547,17 @@ describe('the journey of a nrm application', () => {
       expect(response.text).to.contain('Found. Redirecting to /nrm/pv-phone-number');
     });
 
-    it('goes to the co-operate-with-police-referral page when user selects no phone number', async () => {
+    it('goes to the fr-details page when user selects no phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-phone-number': 'no'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
+      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
     });
 
-    it('goes to the co-operate-with-police-referral page when user enters pv phone number', async () => {
+    it('goes to the fr-details page when user enters pv phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
@@ -565,7 +565,7 @@ describe('the journey of a nrm application', () => {
         'pv-phone-number-yes': '01234567890'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
+      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
     });
 
     it('goes to the someone-else page when user enters who-contact', async () => {
@@ -599,42 +599,22 @@ describe('the journey of a nrm application', () => {
       expect(response.text).to.contain('Found. Redirecting to /nrm/pv-phone-number');
     });
 
-    it('goes to the co-operate-with-police-referral page when user selects no phone number', async () => {
+    it('goes to the fr-details page when user selects no phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-phone-number': 'no'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
+      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
     });
 
-    it('goes to the co-operate-with-police-referral page when user enters pv phone number', async () => {
+    it('goes to the fr-details page when user enters pv phone number', async () => {
       const URI = '/pv-phone-number';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-phone-number': 'yes',
         'pv-phone-number-yes': '01234567890'
-      });
-
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-referral');
-    });
-
-    it('goes to the fr-details page when user selects yes cooperate-with-police-referral', async () => {
-      const URI = '/co-operate-with-police-referral';
-      await initSession(URI);
-      const response = await passStep(URI, {
-        'co-operate-with-police': 'yes'
-      });
-
-      expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
-    });
-
-    it('goes to the fr-details page when user selects not to cooperate-with-police-referral', async () => {
-      const URI = '/co-operate-with-police-referral';
-      await initSession(URI);
-      const response = await passStep(URI, {
-        'co-operate-with-police': 'no'
       });
 
       expect(response.text).to.contain('Found. Redirecting to /nrm/fr-details');
@@ -715,36 +695,16 @@ describe('the journey of a nrm application', () => {
       expect(response.text).to.contain('Found. Redirecting to /nrm/pv-nationality-dtn');
     });
 
-    it('goes to the co-operate-with-police-dtn page when user selects nationality', async () => {
+    it('goes to the confirm page when user selects nationality', async () => {
       const URI = '/pv-nationality-dtn';
       await initSession(URI);
       const response = await passStep(URI, {
         'pv-nationality': 'French'
       });
 
-      expect(response.text).to.contain('Found. Redirecting to /nrm/co-operate-with-police-dtn');
-    });
-
-    it('goes to the confirm page when user selects not to co-operate-with-police', async () => {
-      const URI = '/co-operate-with-police-dtn';
-      await initSession(URI);
-      const response = await passStep(URI, {
-        'co-operate-with-police': 'no'
-      });
-
       expect(response.text).to.contain('Found. Redirecting to /nrm/confirm');
     });
-
-    it('goes to the pv-name-dtn page when user selects to co-operate-with-police', async () => {
-      const URI = '/co-operate-with-police-dtn';
-      await initSession(URI);
-      const response = await passStep(URI, {
-        'co-operate-with-police': 'yes'
-      });
-
-      expect(response.text).to.contain('Found. Redirecting to /nrm/pv-name-dtn');
-    });
-
+    
     it('goes to the pv-contact-details-dtn page when user enters an organisation', async () => {
       const URI = '/pv-name-dtn';
       await initSession(URI);

--- a/test/_ui-integration/nrm/validations.spec.js
+++ b/test/_ui-integration/nrm/validations.spec.js
@@ -1001,22 +1001,6 @@ describe('validation checks of the nrm journey', () => {
     });
   });
 
-  describe('Cooperate with Police Referral Validation', () => {
-    it('does not pass the cooperate with police referral page if nothing is selected', async () => {
-      const URI = '/co-operate-with-police-referral';
-      await initSession(URI);
-      await passStep(URI, {});
-
-      const res = await getUrl(URI);
-      const docu = await parseHtml(res);
-      const validationSummary = docu.find('.validation-summary');
-
-      expect(validationSummary.length === 1).to.be.true;
-      expect(validationSummary.html())
-        .to.match(/You must select an option/);
-    });
-  });
-
   describe('First Responder Contact Details Validations', () => {
     it('does not pass the fr details page if nothing is entered', async () => {
       const URI = '/fr-details';
@@ -1065,22 +1049,6 @@ describe('validation checks of the nrm journey', () => {
       expect(validationSummary.length === 1).to.be.true;
       expect(validationSummary.html())
         .to.match(/You must select the potential victim's nationality from the list/);
-    });
-  });
-
-  describe('Cooperate with Police Dtn Validation', () => {
-    it('does not pass the cooperate with police dtn page if nothing is selected', async () => {
-      const URI = '/co-operate-with-police-dtn';
-      await initSession(URI);
-      await passStep(URI, {});
-
-      const res = await getUrl(URI);
-      const docu = await parseHtml(res);
-      const validationSummary = docu.find('.validation-summary');
-
-      expect(validationSummary.length === 1).to.be.true;
-      expect(validationSummary.html())
-        .to.match(/You must select an option/);
     });
   });
 });

--- a/test/helpers/supertest_session/session-data/nrm/steps.js
+++ b/test/helpers/supertest_session/session-data/nrm/steps.js
@@ -36,7 +36,6 @@ module.exports = [
   '/refuse-nrm',
   '/pv-gender-dtn',
   '/pv-nationality-dtn',
-  '/co-operate-with-police-dtn',
   '/pv-name-dtn',
   '/pv-contact-details-dtn',
   '/does-pv-need-support',
@@ -53,7 +52,6 @@ module.exports = [
   '/someone-else',
   '/pv-contact-details-referral',
   '/pv-phone-number',
-  '/co-operate-with-police-referral',
   '/fr-details',
   '/fr-alternative-contact',
   '/confirm'


### PR DESCRIPTION
## What?
Removed page can police contact them about their case?
path:
 `/co-operate-with-police-referral` and `/co-operate-with-police-dtn`.
## Why?
request from stakeholder [NRM-265](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-265)
and [NRM-279](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-279)
## How?
- removed html page for co-operate with police.
- removed field in fields/index.js, pages.json validation.json, fields.json
- removed partial view from summary-table-potential-victim.html and submission.js
- removed the format answer method related to co-operate with police field
- update tests according to the new changes (TBC when merged with NRM-264)
- update .synk and package.json files
Also removed field `co-operate-with police`.
## Testing?
removed all tests concerning `/nrm/co-operate-with-police-referral` and `/nrm/co-operate-with-police-dtn`page
## Screenshots (optional)
## Anything Else? (optional)

test needs to be continued after merging with NRM-264 

## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging