### PR TITLE
NRM-296-remove acceptance tests from builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -113,21 +113,22 @@ steps:
         include:
           - master
       event: push
-
-  - name: acceptance_tests_deploy
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache docker-compose
-      - docker-compose --verbose up -d --build chrome-browser modern-slavery-main redis
-      - docker-compose exec -T modern-slavery-main sh -c 'npm run test:docker-acceptance'
-    when:
-      branch:
-        include:
-        - master
-      event: push
+  
+  # temporarily commented out because tests are not running properly on drone
+  # - name: acceptance_tests_deploy
+  #   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  #   volumes:
+  #     - name: dockersock
+  #       path: /var/run
+  #   commands:
+  #     - apk add --no-cache docker-compose
+  #     - docker-compose --verbose up -d --build chrome-browser modern-slavery-main redis
+  #     - docker-compose exec -T modern-slavery-main sh -c 'npm run test:docker-acceptance'
+  #   when:
+  #     branch:
+  #       include:
+  #       - master
+  #     event: push
 
   - name: build_image
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
@@ -242,21 +243,22 @@ steps:
           - feature/*
       event: pull_request
 
-  - name: acceptance_tests_branch
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache docker-compose
-      - docker-compose --verbose up -d --build chrome-browser modern-slavery-main redis
-      - docker-compose exec -T modern-slavery-main sh -c 'npm run test:docker-acceptance'
-    when:
-      branch:
-        include:
-          - master
-          - feature/*
-      event: pull_request
+  # temporarily commented out because tests are not running properly on drone
+  # - name: acceptance_tests_branch
+  #   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  #   volumes:
+  #     - name: dockersock
+  #       path: /var/run
+  #   commands:
+  #     - apk add --no-cache docker-compose
+  #     - docker-compose --verbose up -d --build chrome-browser modern-slavery-main redis
+  #     - docker-compose exec -T modern-slavery-main sh -c 'npm run test:docker-acceptance'
+  #   when:
+  #     branch:
+  #       include:
+  #         - master
+  #         - feature/*
+  #     event: pull_request
 
   # Snyk security scans which run after branch deployment to prevent blocking of PR UAT tests
   - name: snyk_scan


### PR DESCRIPTION
## What?
Commented out acceptance tests steps on drone.yml file
## Why?
To temporary fix the build pipeline.
The error is as follows:
_kubernetes has failed: container failed to start: id=drone-yxdct65qen2v1ldzf5g3 exitcode=2 reason=Error image=340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind:latest_
The puppeteer library is causing the issue, might be unstable versioning available.
The acceptance test is causing delays in merging our PRs to the master.
Since E2E automation test are implemented by QA team, dev team agreed to remove it from development environment.
## How?
following instruction on Jira ticket [NRM-296](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-296)
## Testing?
no test required
