### PR TITLE
NRM-mmtest  Icasework-resolver test in NRM

### DIFF
--- a/kube/icasework/icasework-resolver-deployment.yml
+++ b/kube/icasework/icasework-resolver-deployment.yml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: icasework-resolver
           # release v4.2.0
-          image: quay.io/ukhomeofficedigital/icasework-resolver:e847453544f41a85454e055b5a17b91bfc4dfd70
+          image: quay.io/ukhomeofficedigital/icasework-resolver:1206eea5c4af9eb7597ceb7d1b89a63aa7268d23
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What?
- Medium-security-vulnerability-icasework-resolver-aws-sdk-dependency - [HOFF-731](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-731) 
## Why?
icasework-resolver has been updated with security vulnerabilities and needs to be tested in NRM
## How?
- in icasework-resolver-deployment.yml  image: quay.io/ukhomeofficedigital/icasework-resolver:  has been modified with  the image 1206eea5c4af9eb7597ceb7d1b89a63aa7268d23
## Testing?
tests passing
