### PR TITLE
HOFF-731 Fix Medium security vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,56 +4,49 @@ version: v1.22.1
 ignore:
   SNYK-JS-AXIOS-6032459:
     - '*':
-        reason: will be resolved with HOFF-659
+        reason: will be resolved with HOFF-659 
         expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
+        created: 2024-07-16T11:0522.224Z
 
   SNYK-JS-AXIOS-6124857:
     - '*':
-        reason: will be resolved with HOFF-659
+        reason: will be resolved with HOFF-659 
         expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
+        created: 2024-07-16T11:0522.224Z
 
   SNYK-JS-AXIOS-6144788:
     - '*':
-        reason: will be resolved with HOFF-659
+        reason: will be resolved with HOFF-659 
         expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
+        created: 2024-07-16T11:0522.224Z
 
   SNYK-JS-MARKDOWNIT-6483324:
     - '*':
         reason: No upgrade or patch available yet
         expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
-
+        created: 2024-07-16T11:0522.224Z
+      
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: No upgrade or patch available yet
         expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
+        created: 2024-07-16T11:0522.224Z
 
   SNYK-JS-REQUEST-3361831:
     - '*':
         reason: No upgrade or patch available yet
         expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
+        created: 2024-07-16T11:0522.224Z
 
   SNYK-JS-TOUGHCOOKIE-5672873:
     - '*':
-        reason: will be resolved with HOFF-659
-        expires: 2024-10-16T00:00:00.000Z
-        created: 2024-04-16T11:0522.224Z
- 
+        reason: will be resolved with HOFF-659 
+        expires: 2024-10-19T00:00:00.000Z
+        created: 2024-07-16T11:0522.224Z
   SNYK-JS-BRACES-6838727:
     - '*':
-        reason: No upgrade or patch available yet 
-        expires: 2024-10-13T00:00:00.000Z
-        created: 2024-05-13T11:0522.224Z
-  
-  SNYK-JS-ASYNC-7414156:
-    - '*':
-        reason: No upgrade or patch available yet 
-        expires: 2024-10-13T00:00:00.000Z
-        created: 2024-07-02T11:0522.224Z
+        reason: No upgrade or patch available
+        expires: 2024-10-16T00:00:00.000Z
+        created: 2024-07-16T11:0522.224Z
 
 patch: {}

--- a/kube/icasework/icasework-resolver-deployment.yml
+++ b/kube/icasework/icasework-resolver-deployment.yml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: icasework-resolver
           # release v4.2.0
-          image: quay.io/ukhomeofficedigital/icasework-resolver:e847453544f41a85454e055b5a17b91bfc4dfd70
+          image: quay.io/ukhomeofficedigital/icasework-resolver:8ea571f25fe8d928ef97ba60a5b832e8f3fcc4ea
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What?
- Medium-security-vulnerability-icasework-resolver-aws-sdk-dependency - [HOFF-731](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-731) 
## Why?
icasework-resolver has been updated with security vulnerabilities and needs to be tested in NRM
## How?
- In icasework-resolver-deployment.yml image: [quay.io/ukhomeofficedigital/icasework-resolver](http://quay.io/ukhomeofficedigital/icasework-resolver): has been updated
## Testing?
tests passing

## Check list

- [x] I have reviewed my own pull request for linting issues
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging