### PR TITLE
HOFF-839: Set Env variable for UAT to skip email verification

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -130,6 +130,10 @@ spec:
                 secretKeyRef:
                   name: sas-ms-uat-sqs
                   key: access_key_id
+            - name: ALLOW_SKIP
+              value: "true"
+            - name: SKIP_EMAIL
+              value: "sas-hof-test@digital.homeoffice.gov.uk"
             {{ else }}
             - name: AWS_SQS
               valueFrom:


### PR DESCRIPTION
## What?
* Skip email function is used to skip the email verification process while using hof test email.
* QA team are unable to progress due to the email verification process in UAT.
* This isn't a temporary change 


## Why?

- Testers require this feature to assist with their automation scripts. 
- Similar to Branch Env we require to add this feature to UAT env
- Jira link: https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-839

## How?

* Add condition to set the env variables to skip when hof email is used
* This feature has been  setup in Branch Env and requires to setup for UAT
* Requested by Dev's and QA team to assist with the automation scripts

## Testing?
We will test the UAT Ingress url to validate the changes once deployed to UAT ENV.
## Screenshots (optional)
## Anything Else? (optional)
