### PR TITLE
NRM-310 Remove new value on the autoselect component on "What organis…

### DIFF
--- a/ms-lists/ms_organisations.js
+++ b/ms-lists/ms_organisations.js
@@ -3,7 +3,6 @@
 const organisations = [
   {value:"Home Office - UK Border Force UKBF",label:"Home Office - UK Border Force UKBF"},
   {value:"Home Office - UK Visas and Immigration UKVI",label:"Home Office - UK Visas and Immigration UKVI"},
-  {value:"Home Office - Illegal Migration Operations Command IMOC",label:"Home Office - Illegal Migration Operations Command IMOC"},
   {value:"Home Office - Immigration Enforcement IE",label:"Home Office - Immigration Enforcement IE"},
   {value:"Health and Social Care Trusts - HSC Trusts",label:"Health and Social Care Trusts - HSC Trusts"},
   {value:"National Crime Agency NCA",label:"National Crime Agency NCA"},


### PR DESCRIPTION
## What?
removed entry "Home Office - Illegal Migration Operations Command IMOC, from autocomplete input.
## Why?
as per product owner request in jira ticket [NRM-310](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-310)
## How?
- removed entry "Home Office - Illegal Migration Operations Command IMOC, 
- from `ms-lists/ms_organisations.js`
## Testing?
n/a
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
