### PR TITLE
[NRM 341] configured sanitisation method from HoF to work on NRM

### DIFF
--- a/apps/common/behaviours/sanitise-inputs.js
+++ b/apps/common/behaviours/sanitise-inputs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = superclass => class extends superclass {
+  configure(req, res, next) {
+    this.options.sanitiseInputs = true;
+    next();
+  }
+};

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -7,6 +7,9 @@
     "./apps/nrm",
     "./apps/feedback"
   ],
+  "behaviours": [
+    "./apps/common/behaviours/sanitise-inputs"
+  ],
   "getCookies": false,
   "session": {
     "name": "modern-slavery.hof.sid"

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const _ = require('lodash');
 const sessionCookiesTable = require('./apps/common/translations/src/en/cookies.json');
 
 settings.routes = settings.routes.map(route => require(route));
+settings.behaviours = settings.behaviours.map(require);
 settings.views = path.resolve(__dirname, './apps/common/views');
 settings.root = __dirname;
 

--- a/test/_unit/common/sanitse-inputs.spec.js
+++ b/test/_unit/common/sanitse-inputs.spec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const reqres = require('reqres');
+const sanitiseInputs = require('../../../apps/common/behaviours/sanitise-inputs');
+
+// Base middleware class for extending, which contains the sanitiseInputs configurations
+class Base {
+  constructor() {
+    this.options = {};
+  }
+}
+
+describe('sanitise inputs middleware', () => {
+  let req;
+  let res;
+  let next;
+  let SanitisingMiddleware;
+  let instance;
+
+  beforeEach( () => {
+    req = reqres.req(); // Initialize req object
+    res = reqres.res(); // Initialize res object
+    next = sinon.stub(); // Create a stub for the next function
+    SanitisingMiddleware = sanitiseInputs(Base); // Create the class with sanitiseInputs
+    instance = new SanitisingMiddleware({});
+  });
+
+  describe('configure()', () => {
+    it('default sanitisationInputs set to true', () => {
+      instance.configure(req, res, next);
+      expect(instance.options.sanitiseInputs).to.be.true; // Verify that sanitiseInputs has been set to true
+      expect(next).to.have.been.called; // Ensure that next() was called
+    });
+  });
+});


### PR DESCRIPTION
## What?
Fix NRM Live Issue - User getting 504 error when adding square brackets in text area - [NRM-341](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-341)
## Why?
To fix 504 error where users were not able to progress with their case, a rule was added in the HoF Services Config [PR-341](https://github.com/UKHomeOfficeForms/hof-services-config/commit/8979e2e9f3098ef3d20ea5c4817e38865e9b3534) to enable square brackets and a sanitisation method was configured to run on NRM, which would add a hyphen after the square brackets.
## How?
Added a new behaviour to the common directory to configure the sanitisation function to work for NRM. 
## Testing?
tests passing locally and tested on branch
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
