### PR TITLE
NRM-432: fix magic link ampersand bug

### DIFF
--- a/apps/nrm/behaviours/check-email-token.js
+++ b/apps/nrm/behaviours/check-email-token.js
@@ -4,34 +4,36 @@ const config = require('../../../config');
 
 /* eslint no-process-env: 0*/
 module.exports = superclass => class extends superclass {
-  saveValues(req, res, next) {
-    const token = req.query.token;
+  async saveValues(req, res, next) {
+    // remove ?hof-cookie-check query from token if it is present
+    const token = (req.query.token)?.replace('?hof-cookie-check', '');
     const email = req.query.email || config.skipEmail;
 
     const skipEmailAuth = token === 'skip' && config.allowSkip && email;
     const validEmailToken = req.sessionModel.get('valid-token') === true;
-    // skips if it goes to /nrm/start?token=skip
-    // skips if a session is already present.
-    // skips if email params if provided /nrm/start?token=skip&email=s@
-    if (skipEmailAuth || validEmailToken) {
-      req.sessionModel.set('user-email', email);
-      return super.saveValues(req, res, next);
+    try {
+      // skips if it goes to /nrm/start?token=skip
+      // skips if a session is already present.
+      // skips if email params if provided /nrm/start?token=skip&email=s@
+      if (skipEmailAuth || validEmailToken) {
+        req.sessionModel.set('user-email', email);
+        return super.saveValues(req, res, next);
+      }
+      // Await the result of the checkToken.read
+      const user = await checkToken.read(token);
+      if (user.valid) {
+        // delete the token once it's been used
+        await checkToken.delete(token);
+        // this is so a user can go back without requesting a new token
+        req.sessionModel.set('valid-token', true);
+        // store email & org to send to caseworker later
+        req.sessionModel.set('user-email', user.email);
+        return super.saveValues(req, res, next);
+      }
+      return res.redirect('/nrm/token-invalid');
+    } catch (err) {
+      req.log('error', `Check Token Error: ${err}`);
+      return next(err);
     }
-    // returns a Promise
-    return checkToken.read(token)
-      .then(user => {
-        if (user.valid) {
-          // delete the token once it's been used
-          checkToken.delete(token);
-          // this is so a user can go back without requesting a new token
-          req.sessionModel.set('valid-token', true);
-          // store email & org to send to caseworker later
-          req.sessionModel.set('user-email', user.email);
-          return super.saveValues(req, res, next);
-        }
-        return res.redirect('/nrm/token-invalid');
-      })
-      .catch(err => req.log('info', `Check Token Error: ${err}`)
-      );
   }
 };

--- a/apps/verify/behaviours/email-lookup-sender.js
+++ b/apps/verify/behaviours/email-lookup-sender.js
@@ -8,28 +8,28 @@ const templateId = config.govukNotify.templateUserAuthId;
 const appPath = require('../../nrm/index').baseUrl;
 const firstStep = '/start';
 const tokenGenerator = require('../models/save-token');
+const logger = require('hof/lib/logger')({ env: config.env });
 
 const getPersonalisation = (host, token) => {
   return {
-    // pass in `&` at the end in case there is another
-    // query e.g. ?hof-cookie-check
-    'link': `http://${host + appPath + firstStep}?token=${token}&`,
+    'link': `http://${host + appPath + firstStep}?token=${token}`,
     'host': `http://${host}`,
   };
 };
 
-const sendEmail = (email, host, token) => {
-  notifyClient
-    .sendEmail(templateId, email, {
-      personalisation: getPersonalisation(host, token)
-    })
+const sendEmail = async (email, host, token) => {
+  try {
+    await notifyClient
+      .sendEmail(templateId, email, {
+        personalisation: getPersonalisation(host, token)
+      });
     // we will need to log out the response to a proper logger
-    // eslint-disable-next-line no-console
-    .then(console.log(`email sent to ${email}`))
-    .catch(error => {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    });
+    logger.log('info', `email sent to ${email}`);
+  }
+  catch (error) {
+    logger.error(`Error sending email: ${error}`);
+    throw error;
+  };
 };
 
 module.exports = superclass => class extends superclass {
@@ -38,28 +38,35 @@ module.exports = superclass => class extends superclass {
     return config.allowSkip && email === config.skipEmail;
   }
 
-  saveValues(req, res, next) {
+  async saveValues(req, res, next) {
     const email = req.form.values['user-email'];
 
     if (this.skipEmailVerification(email)) {
       return super.saveValues(req, res, next);
     }
-
-    return super.saveValues(req, res, err => {
-      const organisation = req.sessionModel.get('user-organisation');
-      const emailDomain = email.replace(/.*@/, '');
-
-      const isRecognisedEmail = emailDomainCheck.isValidDomain(emailDomain);
-
-      if (!isRecognisedEmail) {
-        req.sessionModel.set('recognised-email', false);
+    return super.saveValues(req, res, async err => {
+      if (err) {
         return next(err);
       }
+      try {
+        const organisation = req.sessionModel.get('user-organisation');
+        const emailDomain = email.replace(/.*@/, '');
 
-      const host = req.get('host');
-      const token = tokenGenerator.save(email, organisation);
-      sendEmail(email, host, token);
-      return next(err);
+        const isRecognisedEmail = emailDomainCheck.isValidDomain(emailDomain);
+
+        if (!isRecognisedEmail) {
+          req.sessionModel.set('recognised-email', false);
+          return next(err);
+        }
+
+        const host = req.get('host');
+        const token = await tokenGenerator.save(email, organisation);
+        await sendEmail(email, host, token);
+        return next();
+      } catch (err) {
+        logger.error('error', `Error in the saveValues method ${error}`);
+        return next(err);
+      }
     });
   }
 

--- a/test/_unit/verify/behaviours/email-lookup-sender.spec.js
+++ b/test/_unit/verify/behaviours/email-lookup-sender.spec.js
@@ -128,7 +128,7 @@ describe('apps/verify/behaviours/email-lookup-sender', () => {
       sandbox.restore();
     });
 
-    it('sets a `recognised-email` to false when an email is not on the whitelist', done => {
+    it('sets a `recognised-email` to false when an email is not on the whitelist', async () => {
       req.form = {
         values: {
           'user-email': 'hello@email.com'
@@ -137,11 +137,10 @@ describe('apps/verify/behaviours/email-lookup-sender', () => {
       emailDomainCheck.isValidDomain.withArgs('hello@email.com').returns(false);
       instance.saveValues(req, res, () => {
         req.sessionModel.set.should.have.been.calledOnce.calledWithExactly('recognised-email', false);
-        done();
       });
     });
 
-    it('calls tokenGenerator if an email is on the whitelist', done => {
+    it('calls tokenGenerator if an email is on the whitelist', async () => {
       req.form = {
         values: {
           'user-email': 'test@homeoffice.gov.uk'
@@ -150,11 +149,10 @@ describe('apps/verify/behaviours/email-lookup-sender', () => {
 
       instance.saveValues(req, res, () => {
         tokenGenerator.save.should.have.been.calledOnce;
-        done();
       });
     });
 
-    it('sends an email if an email is on the whitelist', done => {
+    it('sends an email if an email is on the whitelist', async () => {
       req.form = {
         values: {
           'user-email': 'test@homeoffice.gov.uk'
@@ -163,11 +161,10 @@ describe('apps/verify/behaviours/email-lookup-sender', () => {
 
       instance.saveValues(req, res, () => {
         NotifyClient.prototype.sendEmail.should.have.been.calledOnce;
-        done();
       });
     });
 
-    it('skips calling data service when email auth skip is allowed with correct email', done => {
+    it('skips calling data service when email auth skip is allowed with correct email', async () => {
       req.form = {
         values: {
           'user-email': 'sas-hof-test@digital.homeoffice.gov.uk'
@@ -176,7 +173,6 @@ describe('apps/verify/behaviours/email-lookup-sender', () => {
 
       instance.saveValues(req, res, () => {
         NotifyClient.prototype.sendEmail.should.not.have.been.called;
-        done();
       });
     });
   });


### PR DESCRIPTION
## What?
- Fix bug where an additional ampersand being added to the end of the magic link when clicked causes an engine error - [NRM-342](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-342)
## Why?
-  In the past an `&` was added to the end of the magic link  in the getPersonalisation function in the email-lookup-sender behaviour to resolve a bug where `?hof-cookie-check` was being added to the end of the req.query.token (https://github.com/UKHomeOffice/modern-slavery/commit/8bd6451a3c874ba9326f61d7254ca5a2d06fcfdb)
- Currently, with some clients, due to a second ampersand being generated, an nginx error is triggered when the user clicks the magic link, preventing them from accessing their form.
## How?
- removed the `&` from the link in the getPersonalisation function in email-lookup-sender behaviour
- refactored the token configuration in check-email-token behaviour so that if req.query.token ended with `?hof-cookie-check`, `?hof-cookie-check` would be replaced with empty string.
- added hof logger to functions to improve logging
- refactored behaviours to use async with try/catch blocks for better error handling
## Testing?
- added a unit test to check `?hof-cookie-check` is replaced if present at the end of a token
- refactored relevant unit tests following async refactoring in behaviours
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
