### PR TITLE
[NRM 331] Question not announced by screen reader for exploiters-current-location-details field

### DIFF
--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -101,7 +101,7 @@
     "header": "Who exploited them?"
   },
   "exploiters-current-location-details": {
-    "header": "What information do you have about where the exploiters are now?"
+    "heading": "What information do you have about where the exploiters are now?"
   },
   "types-of-exploitation": {
     "header": "How were they exploited?",

--- a/apps/nrm/views/exploiters-current-location-details.html
+++ b/apps/nrm/views/exploiters-current-location-details.html
@@ -1,0 +1,11 @@
+{{<partials-page}}
+  {{$page-content}}
+  <div tabindex="0">
+    <h1 class="govuk-heading-l">{{#t}}pages.exploiters-current-location-details.heading{{/t}}</h1>
+  </div>
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/nrm/views/where-are-exploiters.html
+++ b/apps/nrm/views/where-are-exploiters.html
@@ -1,6 +1,0 @@
-{{<partials-page}}
-  {{$page-content}}
-    {{#renderField}}exploiters-current-location-details{{/renderField}}
-    {{#input-submit}}continue{{/input-submit}} {{> partials-save-and-exit-link}}
-  {{/page-content}}
-{{/partials-page}}


### PR DESCRIPTION
## What?
Question not announced by screen reader for exploiters-current-location-details field. See [NRM-331](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-331)
## Why?
This could be due to the radio button element set up on the HoF framework. To fix this issue, we updated the pv-under-age HTML page and hard coded the elements.
## How?
A div element was added to include a tab index which was set to 0. This enabled the tab function to pick up the header.
## Testing?
Voice Over was used as a screen reader to test whether the header is being picked up.
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
