### PR TITLE
Revert "[NRM 331] Enabling screen reader to read header and paragraph text"

### DIFF
--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -9,9 +9,7 @@
     "header": "Delete report"
   },
   "pv-under-age": {
-    "heading": "Is the potential victim under 18?",
-    "paragraph-1": "If you’re not sure of the potential victim’s age, you’ll need to refer them to the relevant local authority for an age assessment. They will continue to be treated as a child until a decision on their age is made.",
-    "paragraph-2": "If they’re under 18 or you’re not sure, you must explain to them how organisations such as the Home Office will use their information."
+    "header": "Is the potential victim under 18?"
   },
   "local-authority-contacted-about-child": {
     "header": "Which local authority have you contacted about the child?",

--- a/apps/nrm/views/content/pv-under-age.md
+++ b/apps/nrm/views/content/pv-under-age.md
@@ -1,0 +1,3 @@
+If you’re not sure of the potential victim’s age, you’ll need to refer them to the relevant local authority for an age assessment. They will continue to be treated as a child until a decision on their age is made.
+
+If they’re under 18 or you’re not sure, you must explain to them how organisations such as the Home Office will use their information.

--- a/apps/nrm/views/pv-under-age.html
+++ b/apps/nrm/views/pv-under-age.html
@@ -1,10 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
-  <div tabindex="0">
-    <h1 class="govuk-heading-l">{{#t}}pages.pv-under-age.heading{{/t}}</h1>
-    <p>{{#t}}pages.pv-under-age.paragraph-1{{/t}}</p>
-    <p>{{#t}}pages.pv-under-age.paragraph-2{{/t}}</p>
-  </div>
+    {{#markdown}}pv-under-age{{/markdown}}
     {{#fields}}
       {{#renderField}}{{/renderField}}
     {{/fields}}


### PR DESCRIPTION
## What?
Reverting [NRM-330](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-330) 
## Why?
Screen readers are not working correctly with other pages that contain a text area. Further work is needed to fix the accessibility issues. 
## How?
Reverting following ticket PR: [NRM-330](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-330) and 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [] I have created a JIRA number for my branch
- [] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging