### PR TITLE
NRM-392: "pv last in contact" page

### DIFF
--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -263,6 +263,7 @@ module.exports = {
       'within-the-last-month',
       'within-the-last-3-month',
       'within-the-last-6-month',
+      'within-the-last-6-12-month',
       'over-a-year-ago',
       'not-sure'
     ]

--- a/apps/nrm/index.js
+++ b/apps/nrm/index.js
@@ -187,10 +187,6 @@ module.exports = {
         saveFormSession
       ],
       fields: ['when-last-contact'],
-      forks: [{
-        target: '/is-this-the-first-chance-to-report',
-        condition: req => req.sessionModel.get('when-last-contact') === 'not-sure'
-      }],
       next: '/details-last-contact',
       locals: { showSaveAndExit: true },
       continueOnEdit: true

--- a/apps/nrm/translations/src/en/fields.json
+++ b/apps/nrm/translations/src/en/fields.json
@@ -149,6 +149,9 @@
       "within-the-last-6-month": {
         "label": "Within the last 6 months"
       },
+      "within-the-last-6-12-month": {
+        "label": "Within the last 6-12 months"
+      },
       "over-a-year-ago": {
         "label": "Over a year ago"
       },


### PR DESCRIPTION
## What?
Update the content for the "When were the potential victim and exploiters last in contact?" page
## Why?
As part of a business change request
## How?
* Add new field option for contact between last 6 months and last year
* Add new translation for field for contact between last 6 months and last year
* Remove conditional routing for the not-sure option
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
