### PR TITLE
HOTFIX: Allow filevault host on all branches

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -15,23 +15,13 @@ spec:
   {{ end }}
   selector:
     matchLabels:
-      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-      name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-      service: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-      {{ else }}
       name: file-vault
       service: file-vault
-      {{ end }}
   template:
     metadata:
       labels:
-        {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-        name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-        service: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-        {{ else }}
         name: file-vault
         service: file-vault
-        {{ end }}
     spec:
       containers:
         - name: file-vault

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -2,11 +2,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: file-vault-ingress-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: file-vault-ingress
-  {{ end }}
 {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
   ingressClassName: nginx-external
@@ -40,9 +36,5 @@ spec:
         paths:
         - path: /
           backend:
-            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-            serviceName: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-            {{ else }}
             serviceName: file-vault
-            {{ end }}
             servicePort: 10443

--- a/kube/file-vault/file-vault-network-policy.yml
+++ b/kube/file-vault/file-vault-network-policy.yml
@@ -2,11 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: file-vault-allow-ingress-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: file-vault-allow-ingress
-  {{ end }}
 spec:
   ingress:
   - from:
@@ -20,10 +16,6 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-      name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-      {{ else }}
       name: file-vault
-      {{ end }}
   policyTypes:
   - Ingress

--- a/kube/file-vault/file-vault-service.yml
+++ b/kube/file-vault/file-vault-service.yml
@@ -2,19 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: file-vault
-  {{ end }}
   labels:
-    {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-    role: service-{{ .DRONE_SOURCE_BRANCH }}
-    {{ else }}
     name: file-vault
     role: service
-    {{ end }}
 spec:
   ports:
   - name: http
@@ -22,8 +13,4 @@ spec:
   - name: https
     port: 10443
   selector:
-    {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-    {{ else }}
     name: file-vault
-    {{ end }}


### PR DESCRIPTION
## What?
- remove branch conditional on filevault host so that all branches use the same host and prevent this error:  `for: "STDIN": admission webhook "validate.nginx-external.ingress.kubernetes.io" denied the request: host "fv-ms.ms-branch.homeoffice.gov.uk" and path "/" is already defined in ingress ms-branch/file-vault-ingress-nrm-411-394-408-395`
## Why?
icasework doesn't allow dynamic url hostnames i.e. names changing depending on the branch name they have been given so only one filevault host name can be used for all branches.
## How?

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
