### PR TITLE
HOTFIX: Allow filevault host on all branches

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -15,23 +15,13 @@ spec:
   {{ end }}
   selector:
     matchLabels:
-      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-      name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-      service: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-      {{ else }}
       name: file-vault
       service: file-vault
-      {{ end }}
   template:
     metadata:
       labels:
-        {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-        name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-        service: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-        {{ else }}
         name: file-vault
         service: file-vault
-        {{ end }}
     spec:
       containers:
         - name: file-vault
@@ -56,15 +46,15 @@ spec:
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
             - name: FILE_VAULT_URL
-            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
+          {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv-ms.modernslavery.homeoffice.gov.uk
-            {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
+          {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
               value: https://fv-ms.preprod.ms-notprod.homeoffice.gov.uk
-            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
+          {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
               value: https://fv-ms.uat.ms-notprod.homeoffice.gov.uk
-            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+          {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-ms.{{ .BRANCH_ENV }}.homeoffice.gov.uk
-            {{ end }}
+          {{ end }}
             - name: PORT
               value: "3000"
             - name: CLAMAV_REST_URL
@@ -182,18 +172,18 @@ spec:
             - "--enable-json-logging=true"
           args:
              # the url which is used to retrieve the OpenID configuration
-            {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
+          {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
             - --discovery-url=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/ms-keycloak
-            {{ else }}
+          {{ else }}
             - --discovery-url=https://sso.digital.homeoffice.gov.uk/auth/realms/ms-keycloak-prod
-            {{ end }}
+          {{ end }}
             # the endpoint where requests are proxied to
             - --upstream-url=http://127.0.0.1:3000
             # URls that you wish to protect.
             - --resources=uri=/*
-            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+          {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
-            {{ end }}
+          {{ end }}
           ports:
             - containerPort: 3001
           securityContext:

--- a/kube/file-vault/file-vault-ingress.yml
+++ b/kube/file-vault/file-vault-ingress.yml
@@ -2,14 +2,12 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: file-vault-ingress-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: file-vault-ingress
-  {{ end }}
 {{ file .FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
 spec:
+{{ if or (eq .KUBE_NAMESPACE .STG_ENV) (eq .KUBE_NAMESPACE .PROD_ENV) }}
   ingressClassName: nginx-external
+{{ end }}
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
@@ -40,9 +38,5 @@ spec:
         paths:
         - path: /
           backend:
-            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-            serviceName: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-            {{ else }}
             serviceName: file-vault
-            {{ end }}
             servicePort: 10443

--- a/kube/file-vault/file-vault-network-policy.yml
+++ b/kube/file-vault/file-vault-network-policy.yml
@@ -2,11 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: file-vault-allow-ingress-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: file-vault-allow-ingress
-  {{ end }}
 spec:
   ingress:
   - from:
@@ -20,10 +16,6 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-      name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-      {{ else }}
       name: file-vault
-      {{ end }}
   policyTypes:
   - Ingress

--- a/kube/file-vault/file-vault-service.yml
+++ b/kube/file-vault/file-vault-service.yml
@@ -2,19 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-  {{ else }}
   name: file-vault
-  {{ end }}
   labels:
-    {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-    role: service-{{ .DRONE_SOURCE_BRANCH }}
-    {{ else }}
     name: file-vault
     role: service
-    {{ end }}
 spec:
   ports:
   - name: http
@@ -22,8 +13,4 @@ spec:
   - name: https
     port: 10443
   selector:
-    {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    name: file-vault-{{ .DRONE_SOURCE_BRANCH }}
-    {{ else }}
     name: file-vault
-    {{ end }}


### PR DESCRIPTION
## What?
Remove branch conditional on filevault ingress and service names so that all branches use the same host and prevent this error:  `for: "STDIN": admission webhook "validate.nginx-external.ingress.kubernetes.io" denied the request: host "fv-ms.ms-branch.homeoffice.gov.uk" and path "/" is already defined in ingress ms-branch/file-vault-ingress-...`
## Why?
icasework doesn't allow dynamic url hostnames i.e. names changing depending on the branch name they have been given,  so only one filevault host name can be used for all branches.
Changing to a set filevault hostname resulted in the error:  `for: "STDIN": admission webhook "validate.nginx-external.ingress.kubernetes.io" denied the request: host "fv-ms.ms-branch.homeoffice.gov.uk" and path "/" is already defined in ingress ms-branch/file-vault-ingress-...` when multiple branches were being deployed to branch.
## How?
- remove dynamic filevault ingress and service names so that same host name can be used on all branches
- set ingress class name on stg and prod
- fix indentation
## Testing?
Deploy to branch step no longer throwing the above error in drone when new branches are made off of this one
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant) - N/A
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
