### PR TITLE
NRM-375: Update keycloak urls for prod

### DIFF
--- a/kube/dashboard/dashboard-deployment.yml
+++ b/kube/dashboard/dashboard-deployment.yml
@@ -106,13 +106,29 @@ spec:
             - name: OAUTH_SCOPE
               value: email
             - name: OAUTH_AUTH_URL
+              {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
               value: https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/auth
+              {{ else }}
+              value: https://sso.digital.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/auth
+              {{ end }}
             - name: OAUTH_TOKEN_URL
+              {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
               value: https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/token
+              {{ else }}
+              value: https://sso.digital.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/token
+              {{ end }}
             - name: OAUTH_API_URL
+              {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
               value: https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/userinfo
+              {{ else }}
+              value: https://sso.digital.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/userinfo
+              {{ end }}
             - name: SIGNOUT_REDIRECT_URL
+              {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
               value: https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/logout
+              {{ else }}
+              value: https://sso.digital.homeoffice.gov.uk/auth/realms/ms-keycloak/protocol/openid-connect/logout
+              {{ end }}
             - name: JSON_DASHBOARDS
               value: >
                 [{

--- a/kube/save-return-lookup/deployment.yml
+++ b/kube/save-return-lookup/deployment.yml
@@ -161,7 +161,11 @@ spec:
             # specififes which client is used
             - --client-id=lookup
             # the url which is used to retrieve the OpenID configuration
+            {{ if not (eq .KUBE_NAMESPACE .PROD_ENV) }}
             - --discovery-url=https://sso-dev.notprod.homeoffice.gov.uk/auth/realms/ms-keycloak
+            {{ else }}
+            - --discovery-url=https://sso.digital.homeoffice.gov.uk/auth/realms/ms-keycloak-prod
+            {{ end }}
             # the endpoint where requests are proxied to
             - --upstream-url=https://127.0.0.1:10444
             # URls that you wish to protect.


### PR DESCRIPTION
## What?
[NRM-375](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-375) - Deployment to point to Keycloak PROD URL
[NRM-374](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-374) -  Add OAUTH account into prod Keycloak realm 
## Why?
Discovery url has to be set to keycloak prod
Oath has to be set to point to prod
## How?
- Adding a control flow statement to ensure that anything that is in the prod env is pointing at the right realm
- Hard coded values where only pointing to notprod
## Testing?
Prod mirrors non prod so when this is deployed it should work as expected - We could whitelist an IP on prod to ensure there is not discrepancy
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant) - N/A
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
