### PR TITLE
NRM-388: Amend content on /why-report-now page

### DIFF
--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -291,6 +291,7 @@ module.exports = {
   },
   'why-report-now': {
     mixin: 'textarea',
+    labelClassName: 'visually-hidden',
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     validate: ['required', { type: 'maxlength', arguments: [15000] }],

--- a/apps/nrm/translations/src/en/fields.json
+++ b/apps/nrm/translations/src/en/fields.json
@@ -176,7 +176,7 @@
     }
   },
   "why-report-now": {
-    "label": "Reason for reporting"
+    "label": "Is there anything that prevented the potential victim from reporting this sooner?"
   },
   "why-are-you-making-the-referral": {
     "label": "Reason for referral"

--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -49,7 +49,8 @@
     "second-header": "Details of the last contact (optional)"
   },
   "why-report-now": {
-    "header": "Why are they reporting this now?"
+    "header": "Is there anything that prevented the potential victim from reporting this sooner?",
+    "intro": "Using your professional judgement, tell us about any reasons why they have not reported this until now. For example. emotional distress or trauma."
   },
   "why-are-you-making-the-referral": {
     "header": "Why are you making the referral?",
@@ -267,7 +268,7 @@
         "label": "Is this the first chance they have had to report this?"
       },
       "why-report-now": {
-        "label": "Reason for reporting now"
+        "label": "Is there anything that prevented the potential victim from reporting this sooner?"
       },
       "why-are-you-making-the-referral": {
         "label": "Reason for referral"

--- a/apps/nrm/translations/src/en/validation.json
+++ b/apps/nrm/translations/src/en/validation.json
@@ -93,7 +93,7 @@
     "required": "You must select an option"
   },
   "why-report-now": {
-    "required": "Enter reason for reporting",
+    "required": "Enter anything that prevented the potential victim from reporting this sooner",
     "maxlength": "Enter no more than 15,000 characters"
   },
   "why-are-you-making-the-referral": {

--- a/test/_ui-integration/nrm/validations.spec.js
+++ b/test/_ui-integration/nrm/validations.spec.js
@@ -308,7 +308,7 @@ describe('validation checks of the nrm journey', () => {
 
       expect(validationSummary.length === 1).to.be.true;
       expect(validationSummary.html())
-        .to.match(/Enter reason for reporting/);
+        .to.match(/Enter anything that prevented the potential victim from reporting this sooner/);
     });
   });
 


### PR DESCRIPTION
## What?
NRM-388: Amend content on /why-report-now page - [NRM-388](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-388)
## Why?
per business request
## How?
- amend header content
- add intro content
- make label visually hidden
- amend check your answers label
- amend validation message to fit amended content
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
