### PR TITLE
NRM-393: Amend content for first chance to report page

### DIFF
--- a/apps/nrm/fields/index.js
+++ b/apps/nrm/fields/index.js
@@ -344,11 +344,21 @@ module.exports = {
     validate: ['required'],
     isPageHeading: true,
     options: [
-      'yes',
+      {
+        value: 'yes',
+        toggle: 'yes-the-first-chance-to-report',
+        child: 'textarea'
+      },
       'no',
-      'not-sure'
+      {
+        value: 'not-sure',
+        toggle: 'not-sure-the-first-chance-to-report',
+        child: 'textarea'
+      }
     ]
   },
+  'yes-the-first-chance-to-report': createDependentFieldConfig('yes', 'is-this-the-first-chance-to-report'),
+  'not-sure-the-first-chance-to-report': createDependentFieldConfig('not-sure', 'is-this-the-first-chance-to-report'),
   'why-report-now': {
     mixin: 'textarea',
     labelClassName: 'visually-hidden',

--- a/apps/nrm/index.js
+++ b/apps/nrm/index.js
@@ -249,7 +249,8 @@ module.exports = {
         saveFormSession
       ],
       locals: { showSaveAndExit: true },
-      fields: ['is-this-the-first-chance-to-report'],
+      fields: ['is-this-the-first-chance-to-report', 'yes-the-first-chance-to-report',
+        'not-sure-the-first-chance-to-report'],
       forks: [{
         target: '/why-report-now',
         condition: {

--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -245,6 +245,13 @@ module.exports = (data, token) => {
     'not-sure': 'Not sure'
   };
   response.FirstChanceToReport = firstChangeToReport[data['is-this-the-first-chance-to-report']];
+
+  if(data['is-this-the-first-chance-to-report'] === 'yes') {
+    response.ReportedBeforeFurtherInfo = data['yes-the-first-chance-to-report'];
+  } else if(data['is-this-the-first-chance-to-report'] === 'not-sure') {
+    response.ReportedBeforeFurtherInfo = data['not-sure-the-first-chance-to-report'];
+  }
+
   response.ReasonForReportingNow = data['why-report-now'];
   response.ReasonForMakingReferral = data['why-are-you-making-the-referral'];
   response.IdentifiedModernSlaveryIndicators = data['modern-slavery-indicators'];

--- a/apps/nrm/sections/summary-data-sections.js
+++ b/apps/nrm/sections/summary-data-sections.js
@@ -275,6 +275,14 @@ module.exports = {
         field: 'is-this-the-first-chance-to-report'
       },
       {
+        step: '/is-this-the-first-chance-to-report',
+        field: 'yes-the-first-chance-to-report'
+      },
+      {
+        step: '/is-this-the-first-chance-to-report',
+        field: 'not-sure-the-first-chance-to-report'
+      },
+      {
         step: '/why-report-now',
         field: 'why-report-now'
       },

--- a/apps/nrm/translations/src/en/fields.json
+++ b/apps/nrm/translations/src/en/fields.json
@@ -186,7 +186,7 @@
     "label": "Tell us about the last contact between the potential victim and their exploiters"
   },
   "is-this-the-first-chance-to-report": {
-    "legend": "Is this the first chance they have had to report this?",
+    "legend": "Has the potential victim reported this before?",
     "options": {
       "yes": {
         "label": "Yes"
@@ -198,6 +198,14 @@
         "label": "Not sure"
       }
     }
+  },
+  "yes-the-first-chance-to-report": {
+    "label": "Provide more information (optional)",
+    "hint": "If you know them, include any NRM or Home Office reference numbers."
+  },
+  "not-sure-the-first-chance-to-report": {
+    "label": "Provide more information (optional)",
+    "hint": "If you know them, include any NRM or Home Office reference numbers."
   },
   "why-report-now": {
     "label": "Is there anything that prevented the potential victim from reporting this sooner?"

--- a/apps/nrm/translations/src/en/pages.json
+++ b/apps/nrm/translations/src/en/pages.json
@@ -303,7 +303,7 @@
         "label": "Details of last contact"
       },
       "is-this-the-first-chance-to-report": {
-        "label": "Is this the first chance they have had to report this?"
+        "label": "Have they reported this before?"
       },
       "why-report-now": {
         "label": "Is there anything that prevented the potential victim from reporting this sooner?"

--- a/apps/nrm/translations/src/en/validation.json
+++ b/apps/nrm/translations/src/en/validation.json
@@ -102,6 +102,12 @@
   "is-this-the-first-chance-to-report": {
     "required": "You must select an option"
   },
+  "yes-the-first-chance-to-report" : {
+    "maxlength": "Information provided must be 15000 characters or less"
+  },
+  "not-sure-the-first-chance-to-report" : {
+    "maxlength": "Information provided must be 15000 characters or less"
+  },
   "why-report-now": {
     "required": "Enter anything that prevented the potential victim from reporting this sooner",
     "maxlength": "Enter no more than 15,000 characters"

--- a/test/_ui-integration/nrm/application.spec.js
+++ b/test/_ui-integration/nrm/application.spec.js
@@ -242,6 +242,26 @@ describe('the journey of a nrm application', () => {
     expect(response.text).to.contain('Found. Redirecting to /nrm/why-report-now');
   });
 
+  it('goes to the modern-slavery-indicators page when user selects yes', async () => {
+    const URI = '/is-this-the-first-chance-to-report';
+    await initSession(URI);
+    const response = await passStep(URI, {
+      'is-this-the-first-chance-to-report': 'yes'
+    });
+
+    expect(response.text).to.contain('Found. Redirecting to /nrm/modern-slavery-indicators');
+  });
+
+  it('goes to the modern-slavery-indicators page when user selects not-sure', async () => {
+    const URI = '/is-this-the-first-chance-to-report';
+    await initSession(URI);
+    const response = await passStep(URI, {
+      'is-this-the-first-chance-to-report': 'not-sure'
+    });
+
+    expect(response.text).to.contain('Found. Redirecting to /nrm/modern-slavery-indicators');
+  });
+
   it('goes to the modern-slavery-indicators page when user enters why are they reporting this now?', async () => {
     const URI = '/why-report-now';
     await initSession(URI);

--- a/test/_ui-integration/nrm/automatic-referral-application.spec.js
+++ b/test/_ui-integration/nrm/automatic-referral-application.spec.js
@@ -256,6 +256,26 @@ describe('the journey of a nrm automatic referral application', () => {
     expect(response.text).to.contain('Found. Redirecting to /nrm/why-report-now');
   });
 
+  it('goes to the modern-slavery-indicators page when user selects yes', async () => {
+    const URI = '/is-this-the-first-chance-to-report';
+    await initSession(URI);
+    const response = await passStep(URI, {
+      'is-this-the-first-chance-to-report': 'yes'
+    });
+
+    expect(response.text).to.contain('Found. Redirecting to /nrm/modern-slavery-indicators');
+  });
+
+  it('goes to the modern-slavery-indicators page when user selects not-sure', async () => {
+    const URI = '/is-this-the-first-chance-to-report';
+    await initSession(URI);
+    const response = await passStep(URI, {
+      'is-this-the-first-chance-to-report': 'not-sure'
+    });
+
+    expect(response.text).to.contain('Found. Redirecting to /nrm/modern-slavery-indicators');
+  });
+
   it('goes to the modern-slavery-indicators page when user enters why are they reporting this now?', async () => {
     const URI = '/why-report-now';
     await initSession(URI);

--- a/test/_ui-integration/nrm/validations.spec.js
+++ b/test/_ui-integration/nrm/validations.spec.js
@@ -368,6 +368,40 @@ describe('validation checks of the nrm journey', () => {
       expect(validationSummary.html())
         .to.match(/You must select an option/);
     });
+
+    it('does not pass is this the first chance to report page if user selects yes and enters more than 15000 characters', async () => {
+      const URI = '/is-this-the-first-chance-to-report';
+      await initSession(URI);
+      await passStep(URI, {
+        'is-this-the-first-chance-to-report': 'yes',
+        'yes-the-first-chance-to-report': 'a'.repeat(15001)
+      });
+
+      const res = await getUrl(URI);
+      const docu = await parseHtml(res);
+      const validationSummary = docu.find('.govuk-error-summary');
+
+      expect(validationSummary.length === 1).to.be.true;
+      expect(validationSummary.html())
+        .to.match(/Information provided must be 15000 characters or less/);
+    });
+
+    it('does not pass is this the first chance to report page if user selects not-sure and enters more than 15000 characters', async () => {
+      const URI = '/is-this-the-first-chance-to-report';
+      await initSession(URI);
+      await passStep(URI, {
+        'is-this-the-first-chance-to-report': 'not-sure',
+        'not-sure-the-first-chance-to-report': 'a'.repeat(15001)
+      });
+
+      const res = await getUrl(URI);
+      const docu = await parseHtml(res);
+      const validationSummary = docu.find('.govuk-error-summary');
+
+      expect(validationSummary.length === 1).to.be.true;
+      expect(validationSummary.html())
+        .to.match(/Information provided must be 15000 characters or less/);
+    });
   });
 
   describe('User enters why are they reporting this now Validation', () => {


### PR DESCRIPTION
## What?
Amend content and routing for the "Has the potential victim reported this before page"
## Why?
As part of a business change request
## How?
* Added new child textbox components "not-sure-the-first-chance-to-report" and "yes-the-first-chance-to-report" in fields/index.js so that more detail can be provided as well as amend content for the "is-the-first-chance-to-report" field
* Added new translations for these fields in translations/en/validation.json
* Updated validations unit test to cover cases where new fields exceed 15k characters
* Add new application and automatic referral tests to cover yes and not-sure routing
* Add new API mapping in submission.js
* Add translations for the new fields in translations/en/fields.json as well as amend translation for the "is-the-first-chance-to-report" field 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
