### PR TITLE
NRM-432: Fix modern slavery indicators field showing as lower case in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,4 +241,3 @@ There are a bunch of microservices as part of modernslavery:
 for legacy information saved as part of the 'save and return' process, so users can update if required before submission. 
 This page should be reviewed within 12 months to see if any active cases in the 'save and return' feature are using this
 field before the page can be permanently removed.
-

--- a/apps/nrm/models/submission.js
+++ b/apps/nrm/models/submission.js
@@ -254,7 +254,7 @@ module.exports = (data, token) => {
 
   response.ReasonForReportingNow = data['why-report-now'];
   response.ReasonForMakingReferral = data['why-are-you-making-the-referral'];
-  response.IdentifiedModernSlaveryIndicators = data['modern-slavery-indicators'];
+  response.IdentifiedModernSlaveryIndicators = _.upperFirst(data['modern-slavery-indicators']);
   response.IdentifiedModernSlaveryIndicatorsDetails = data['modern-slavery-indicators-details'];
   response.ProfessionalInsight = data['professional-insight'];
   response.DetailsAboutInterview = data['where-how-interview-carried-out'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,9 +1413,9 @@ camelize@1.0.0:
   integrity sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg==
 
 caniuse-lite@^1.0.30001688:
-  version "1.0.30001712"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz#41ee150f12de11b5f57c5889d4f30deb451deedf"
-  integrity sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==
+  version "1.0.30001713"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz#6b33a8857e6c7dcb41a0caa2dd0f0489c823a52d"
+  integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==
 
 chai-as-promised@^7.1.1:
   version "7.1.2"
@@ -2176,9 +2176,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.73:
-  version "1.5.132"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.132.tgz#081b8086d7cecc58732f7cc1f1c19306c5510c5f"
-  integrity sha512-QgX9EBvWGmvSRa74zqfnG7+Eno0Ak0vftBll0Pt2/z5b3bEGYL6OUXLgKPtvx73dn3dvwrlyVkjPKRRlhLYTEg==
+  version "1.5.136"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz#854b45e6a892137762cb026ed6ec77391fc5c07b"
+  integrity sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==
 
 elliptic@^6.5.3, elliptic@^6.5.5:
   version "6.6.1"


### PR DESCRIPTION
## What?
Fix modern slavery indicators field showing as lower case in icasework - [NRM-432](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-432)
## Why?
Lower case value observed on the new iCasework fields - Did you identify any modern slavery indicators
## How?
- Made first letter of modern slavery indicators data upper case in model/submission.js
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
- update yarn lock
- fix whitespace in ReadMe
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant) - N/A
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
