### PR TITLE
NRM-435: Fix typo in content - 'How can the support provider contact the potential victim?' page (/pv-phone-number)

### DIFF
--- a/apps/nrm/translations/src/en/fields.json
+++ b/apps/nrm/translations/src/en/fields.json
@@ -641,7 +641,7 @@
     "label": "Relationship to potential victim"
   },
   "no-contact-details": {
-    "label": "If the potential victim wants to receive support and does not have a telephone number, you can nd who it will be shared with. This is contained in the <a class=\"govuk-link\" href=\"/support-organisations\" target=\"_blank\">contact the  support provider (opens in new tab)</a> for them."
+    "label": "If the potential victim wants to receive support and does not have a telephone number, you can <a class=\"govuk-link\" href=\"/support-organisations\" target=\"_blank\">contact the support provider (opens in new tab)</a> for them."
   },
   "pv-name-first-name": {
     "label": "First name"


### PR DESCRIPTION
## What?
Fix typo in content - 'How can the support provider contact the potential victim?' page (/pv-phone-number) - [NRM-435](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-435)
## Why?
- to fix typo
## How?
- amended content in fields.json
## Testing?
tests passing locally and on branch
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
