### PR TITLE
NRM-446 bugfix save-exit button

### DIFF
--- a/apps/nrm/behaviours/casework-submission.js
+++ b/apps/nrm/behaviours/casework-submission.js
@@ -28,6 +28,9 @@ module.exports = conf => {
         if (err) {
           return next(err);
         }
+        if (req.body['save-and-exit']) {
+          return res.redirect('/nrm/save-and-exit');
+        }
         try {
           const model = new GetFileToken();
           const token = await model.auth();


### PR DESCRIPTION
## What?
Bug fix : The "Save and exit" option is submitting the form but this should not be happening. 

After investigation detected when `save and exit ` button was clicked the `caseworker-submission` behaviour was also triggered and this latter was submitting the form.
## Why?
as per business request on Jira ticket [NRM-446](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-446)
## How?
Solution: I added a conditional statement to `casework-submission.js` behaviour, so when `save and exit` is clicked it will redirect the user to the `save and exit page` instead of executing the code.
- update casework-submission.js 
## Testing?
manual on local and on branch
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
