### PR TITLE
NRM-437 [bug-fix] content correction

### DIFF
--- a/apps/nrm/translations/src/en/validation.json
+++ b/apps/nrm/translations/src/en/validation.json
@@ -74,7 +74,7 @@
     "maxlength": "Enter no more than 15,000 characters"
   },
   "what-were-they-required-to-do": {
-    "required": "Enter what were they had to do",
+    "required": "Enter what they had to do",
     "maxlength": "Enter no more than 15,000 characters"
   },
   "living-conditions": {

--- a/test/_ui-integration/nrm/validations.spec.js
+++ b/test/_ui-integration/nrm/validations.spec.js
@@ -267,7 +267,7 @@ describe('validation checks of the nrm journey', () => {
 
       expect(validationSummary.length === 1).to.be.true;
       expect(validationSummary.html())
-        .to.match(/Enter what were they had to do/)
+        .to.match(/Enter what they had to do/)
         .to.match(/Enter how they were treated/)
         .to.match(/Enter their living conditions/);
     });


### PR DESCRIPTION
## What?
Bug fix Correct validation typo for 'what-were-they-required-to-do' field
## Why?
As reporter in [NRM-437](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-437) there was a grammar error in the validation sentence for this field.
## How?
- update validation content for `what-were-they-required-to-do` field in `validation.json`
## Testing?
n/a
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
