### PR TITLE
NRM-458 Fix error missed on file upload

### DIFF
--- a/apps/nrm/models/file-upload.js
+++ b/apps/nrm/models/file-upload.js
@@ -30,7 +30,15 @@ module.exports = class UploadModel extends Model {
       reqConf.headers = {
         ...formData.getHeaders()
       };
-      const result = await this.request(reqConf);
+
+      const result = await this.request(reqConf, error => {
+        // Callback will be called with the error if any is encountered during file load
+        if (error) {
+          // Throw error to be caught below.
+          // Only throw if it exists since callback can also be called without error.
+          throw error;
+        }
+      });
       this.set({ url: result.url });
       logger.info('Successfully saved data');
       return this.unset('data');

--- a/apps/nrm/models/file-upload.js
+++ b/apps/nrm/models/file-upload.js
@@ -39,6 +39,13 @@ module.exports = class UploadModel extends Model {
           throw error;
         }
       });
+
+      // We expect the response to contain a URL, otherwise something went wrong
+      if (!result.url) {
+        const errorMsg = 'Did not receive a URL from file-vault';
+        throw new Error(errorMsg);
+      }
+
       this.set({ url: result.url });
       logger.info('Successfully saved data');
       return this.unset('data');

--- a/test/_unit/nrm/models/file-upload.spec.js
+++ b/test/_unit/nrm/models/file-upload.spec.js
@@ -67,6 +67,40 @@ describe('File Upload Model', () => {
       }
     });
 
+    it('rejects if api call triggers callback with error', async () => {
+      const model = new Model({
+        data: 'foo',
+        name: 'myfile.png',
+        mimetype: 'image/png'
+      });
+      const err = new Error('test error');
+
+      // Causes the stub to call the first callback it receives with the provided arguments
+      model.request.yields(err);
+      try {
+        await model.save();
+      } catch (e) {
+        expect(e).to.equal(err);
+      }
+    });
+
+    it('throws error if response does not have a URL', async () => {
+      const model = new Model({
+        data: 'foo',
+        name: 'myfile.png',
+        mimetype: 'image/png'
+      });
+      const dataNoUrl = new Error({
+        api: 'response'
+      });
+      model.request.resolves(dataNoUrl);
+      try {
+        await model.save();
+      } catch (e) {
+        expect(e.message).to.equal('Did not receive a URL from file-vault');
+      }
+    });
+
     it('adds a formData property to api request with details of uploaded file', async () => {
       const uploadedFile = new Model({
         data: 'foo',

--- a/test/_unit/nrm/models/file-upload.spec.js
+++ b/test/_unit/nrm/models/file-upload.spec.js
@@ -90,9 +90,9 @@ describe('File Upload Model', () => {
         name: 'myfile.png',
         mimetype: 'image/png'
       });
-      const dataNoUrl = new Error({
+      const dataNoUrl = {
         api: 'response'
-      });
+      };
       model.request.resolves(dataNoUrl);
       try {
         await model.save();


### PR DESCRIPTION
## What?
Raised in separate ticket: [NRM-458](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-458)

## Why?
Fix error associated with [NRM-457](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-457)

## How?
* When an error occurs during Model request() call it is returned instead of thrown
* This means we need to explicitly handle the error in a callback
* Otherwise the app will behave as if the upload was successful, but then crashes on submit 

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
