### PR TITLE
NRM-445 Form clear out on failure

### DIFF
--- a/apps/nrm/behaviours/delete-form-session.js
+++ b/apps/nrm/behaviours/delete-form-session.js
@@ -13,14 +13,41 @@ module.exports = superclass => class extends superclass {
         next(err);
       }
 
+      // Before deleting the report, we need to ensure that the submission time matches the one stored in the session.
+      // This prevents deletions of reports when the submission has gone wrong.
       try {
         const model = new Model();
-        const params = {
-          url: `${config.saveService.host}:${config.saveService.port}/reports/${encodeEmail(req.sessionModel.get('user-email'))}/${req.sessionModel.get('id')}`,
-          method: 'DELETE'
+        const reportUrl = `${config.saveService.host}:${config.saveService.port}/reports/${encodeEmail(req.sessionModel.get('user-email'))}/${req.sessionModel.get('id')}`;
+
+        // Get submission time from session
+        const sessionSubmissionTime = String(req.sessionModel.get('submitted-at'));
+
+        // Ger submission time from the db
+        const getParams = {
+          url: reportUrl,
+          method: 'GET'
         };
-        await model._request(params);
-        return next();
+
+        const response = await model._request(getParams);
+        const resBody = response.data;
+
+        let dbSubmissionTime = null;
+
+        if (resBody && resBody.length && resBody[0].submitted_at) {
+          dbSubmissionTime = String(resBody[0].submitted_at);
+        }
+
+        // Compare the submission times and only delete if they match
+        if(dbSubmissionTime && dbSubmissionTime === sessionSubmissionTime) {
+          const delParams = {
+            url: reportUrl,
+            method: 'DELETE'
+          };
+          await model._request(delParams);
+          return next();
+        }
+
+        throw new Error(`Submission time mismatch: ${dbSubmissionTime} does not match ${sessionSubmissionTime}`);
       } catch (error) {
         logger.error(`Error deleting data: ${error.message}`);
         return next(error);


### PR DESCRIPTION
## What?
Short Summary:
* Form data is deleted even when submission fails
* Used to check submission worked correctlyAdding a submitted_at column to db
* Record submitted_at time in DB and session
* Check and compare submitted_at times before deleting data 
[NRM-445](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-445)

Full Summary:

Summary of issue:

This issue is connected to several other issues that I believe are combining to cause the user to lose their data:

- Issue 1: A problem occuring with the file upload fo filevault. As yet unknown cause. Needs to be replicated.
- Issue 2: The upload issue is not being handled correctly by the service and is not displayed to the user. They do not know that the file upload has failed. When the user attempts to submit their form, the server returns an error. This is because the error was returned in place of the normal response data, and stored in the session. This caused the service to error (submission.js line 271). A fix has been created in the service to address this: Could have a framework fix at a later date.
- Issue 3: All the user's data is deleted from the database when the submission happens, even if the submission has gone wrong.

In order to tackle issue 3, we are attempting to add a "submitted_at" column to the database, save the time of submission to this (and also into the local session). When the casework-submission behaviour runs, we will set the submitted_at time. When the delete-form-session behaviour runs, we will check that the submitted_at time in the database is set and matches the submitted-at time in the local session.

These changes have been tested locally, however order to test this on an environment, we need to deploy these changes.

The ms-schema repo needs to be updated, and then the following microservices need to be updated:


These microservices have multiple packages that are out of date, as well as the node version they are using. This is causing the snyc scans to fail (it looks like the automatically-scheduled scans have been failing for a long time).
We can fix this by updating the dependencies and node versions. This can be raised as a separate task if necessary. In that case. we need to disable the snyc scans.

Links:
New package created to test changes:
https://www.npmjs.com/package/modern-slavery-schema
(Can be deleted when no longer needed)

Pull request to update ms-schema:
https://github.com/UKHomeOffice/ms-schema/pull/21

Pull request to update save-return-api to add submitted_at column:
https://github.com/UKHomeOffice/save-return-api/pull/11
(currently pointing to temporary schema package)

Updates to save-return-email-alerts
https://github.com/UKHomeOffice/save-return-email-alerts/pull/10
(pointng to new package)

Updates to save-return-lookup-ui
https://github.com/UKHomeOffice/save-return-lookup-ui/pull/9
(pointing to new package)

## Why?
## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
