### PR TITLE
NRM-463 fix save and exit page title

### DIFF
--- a/apps/nrm/translations/src/en/save-and-exit.json
+++ b/apps/nrm/translations/src/en/save-and-exit.json
@@ -1,3 +1,4 @@
 {
-    "header": "Your report has been saved"
+    "header": "Your report has been saved",
+    "title": "Your report has been saved"
 }

--- a/apps/verify/behaviours/email-lookup-sender.js
+++ b/apps/verify/behaviours/email-lookup-sender.js
@@ -64,7 +64,7 @@ module.exports = superclass => class extends superclass {
         await sendEmail(email, host, token);
         return next();
       } catch (err) {
-        logger.error('error', `Error in the saveValues method ${error}`);
+        logger.error('error', `Error in the saveValues method ${err}`);
         return next(err);
       }
     });


### PR DESCRIPTION
## What?
[NRM-463](https://collaboration.homeoffice.gov.uk/jira/browse/NRM-463) - Incorrect page title
## Why?
Expected outcome: The page title was suppose to be - Your report has been saved – Report modern slavery – GOV.UK

Actual outcome: save-and-exit.title – Report modern slavery – GOV.UK

## How?

save-and-exit.json file is updated with title property

## Testing?
Local and branch testing

## Screenshots (optional)

<img width="1167" height="647" alt="Screenshot 2025-09-25 at 12 45 07" src="https://github.com/user-attachments/assets/9b55ceba-37d5-4fac-b4da-e8732de86e43" />

<img width="1168" height="571" alt="Screenshot 2025-09-25 at 12 45 29" src="https://github.com/user-attachments/assets/28276b7b-4f38-462c-bc8d-8cddf311121d" />



## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
